### PR TITLE
Many updates to protocol & implementation docs.

### DIFF
--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -284,7 +284,7 @@ async function processUpdate(entity, leafHash, rootHash){
 # Blockchain REST API
 The blockchain REST API interface aims to abstract the underlying blockchain away from the main protocol logic. This allows the underlying blockchain to be replaced without affecting the core protocol logic. The interface also allows the protocol logic to be implemented in an entirely different language while interfacing with the same blockchain.
 
-All hashes used in the API are Base64URL encoded SHA256 hash.
+All hashes used in the API are Base58 encoded multihash.
 
 >TODO: Decide on signature format.
 >TODO: Decide on compression.
@@ -334,7 +334,7 @@ GET /v1.0/
 ```
 ```json
 {
-  "afterHash": "exKwW0HjS5y4zBtJ7vYDwglYhtckdO15JDt1j5F5Q0A"
+  "afterHash": "QmWd5PH6vyRH5kMdzZRPBnf952dbR4av3Bd7B2wBqMaAcf"
 }
 ```
 
@@ -346,7 +346,7 @@ GET /v1.0/
     {
       "confirmationTime": "The timestamp in ISO 8601 format 'YYYY-MM-DDThh:mm:ssZ' indicating when this hash was
         anchored to the blockchain.",
-      "hash": "N-JQZifsEIzwZDVVrFnLRXKREIVTFhSFMC1pt08WFzI"
+      "hash": "Hash of the anchor file."
     }
   ]
 }
@@ -359,11 +359,11 @@ GET /v1.0/
   "anchorFileHashes": [
     {
       "confirmationTime": "2018-09-13T19:20:30Z",
-      "hash": "b-7y19k4vQeYAqJXqphGcTlNoq-aQSGm8JPlE_hLmzA"
+      "hash": "QmWd5PH6vyRH5kMdzZRPBnf952dbR4av3Bd7B2wBqMaAcf"
     },
     {
       "confirmationTime": "2018-09-13T20:00:00Z",
-      "hash": "N-JQZifsEIzwZDVVrFnLRXKREIVTFhSFMC1pt08WFzI"
+      "hash": "QmbJGU4wNti6vNMGMosXaHbeMHGu9PkAUZtVBb2s2Vyq5d"
     }
   ]
 }
@@ -400,7 +400,7 @@ POST /v1.0/
 ```
 ```json
 {
-  "anchorFileHash": "exKwW0HjS5y4zBtJ7vYDwglYhtckdO15JDt1j5F5Q0A"
+  "anchorFileHash": "QmbJGU4wNti6vNMGMosXaHbeMHGu9PkAUZtVBb2s2Vyq5d"
 }
 ```
 
@@ -428,7 +428,7 @@ None.
 
 ### Request example
 ```
-Get /v1.0/confirmation-time/9vdoaofs7Cau0tYbOeSmF_8WY7O1i2Wf-alw-yFJRN8
+Get /v1.0/confirmation-time/QmbJGU4wNti6vNMGMosXaHbeMHGu9PkAUZtVBb2s2Vyq5d
 ```
 
 ### Response body schema
@@ -484,6 +484,8 @@ Get /v1.0/block-hash/last
 # CAS REST API Interface
 The CAS (content addressable storage) REST API interface aims to abstract the underlying Sidetree storage away from the main protocol logic. This allows the CAS to be updated or even replaced if needed without affecting the core protocol logic. Conversely, the interface also allows the protocol logic to be implemented in an entirely different language while interfacing with the same CAS.
 
+All hashes used in the API are Base58 encoded multihash.
+
 ## Response HTTP status codes
 
 | HTTP status code | Description                              |
@@ -503,12 +505,12 @@ Read the content of a given address and return it in the response body as octet-
 
 ### Request path
 ```
-GET /<api-version>/<base64url-sha256-hash>
+GET /<api-version>/<hash>
 ```
 
 ### Request example
 ```
-GET /v1.0/b-7y19k4vQeYAqJXqphGcTlNoq-aQSGm8JPlE_hLmzA
+GET /v1.0/QmWd5PH6vyRH5kMdzZRPBnf952dbR4av3Bd7B2wBqMaAcf
 ```
 ### Response headers
 | Name                  | Value                  |
@@ -541,13 +543,13 @@ POST /<api-version>/
 ### Response body schema
 ```json
 {
-  "hash": "Base64URL encoded SHA256 Hash of data written to CAS"
+  "hash": "Hash of data written to CAS"
 }
 ```
 
 ### Response body example
 ```json
 {
-  "hash": "b-7y19k4vQeYAqJXqphGcTlNoq-aQSGm8JPlE_hLmzA"
+  "hash": "QmWd5PH6vyRH5kMdzZRPBnf952dbR4av3Bd7B2wBqMaAcf"
 }
 ```

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -300,10 +300,10 @@ All hashes used in the API are Base58 encoded multihash.
 | 500              | Server error.                            |
 
 
-## Fetch Sidetree anchor file hashes
-Fetches Sidetree anchor file hashes in chronological order.
+## Fetch Sidetree transactions
+Fetches Sidetree transactions in chronological order.
 
->Note: The call may not to return all the known hashes in one batch, in which case the caller can use the last hash given in the returned batch of hashes to fetch subsequent hashes.
+> Note: The call may not to return all Sidetree transactions in one batch, in which case the caller can use the block number of the last given transaction to fetch subsequent transactions.
 
 |                     |      |
 | ------------------- | ---- |
@@ -311,7 +311,7 @@ Fetches Sidetree anchor file hashes in chronological order.
 
 ### Request path
 ```
-GET /<api-version>/
+GET /<api-version>/transactions/
 ```
 
 ### Request headers
@@ -322,33 +322,32 @@ GET /<api-version>/
 ### Request body schema
 ```json
 {
-  "afterHash": "Optional. A valid Sidetree anchor file hash. When not given, all Sidetree anchor file hashes since
-                inception will be returned. When given, only anchor file hashes after the given hash will be
-                returned."
+  "afterBlockNumber": "Optional. A valid block number. When not given, all Sidetree transactions since
+    inception will be returned. When given, only anchor file hashes after the given hash will be returned.
 }
 ```
 
 ### Request example
 ```
-GET /v1.0/
+GET /v1.0/transactions/
 ```
 ```json
 {
-  "afterHash": "QmWd5PH6vyRH5kMdzZRPBnf952dbR4av3Bd7B2wBqMaAcf"
+  "afterBlockNumber": 535236
 }
 ```
 
 ### Response body schema
 ```json
 {
-  "hasMoreHashes": "True if there are more hashes beyond the returned batch of hashes. False otherwise.",
-  "anchorFileHashes": [
+  "moreTransactions": "True if there are more transactions beyond the returned batch. False otherwise.",
+  "transactions": [
     {
-      "blockNumber": "The block number of the block that contains the anchor file hash. Used for ordering.",
-      "blockHash": "A hash of the block that contains the anchor file hash.",
+      "blockNumber": "The block number of the block that contains this transaction. Used for ordering.",
+      "blockHash": "A hash of the block that contains this transaction.",
       "transactionIndex": "The index to this transaction among all the transactions in the block.
                            Used to order multiple Sidetree transactions in the same block.",
-      "hash": "Hash of the anchor file."
+      "anchorFileHash": "Hash of the anchor file of this transaction."
     }
   ]
 }
@@ -357,27 +356,27 @@ GET /v1.0/
 ### Response body example
 ```json
 {
-  "hasMoreHashes": false,  
-  "anchorFileHashes": [
+  "moreTransactions": false,  
+  "transactions": [
     {
       "blockNumber": 545236,
       "blockHash": "0000000000000000002443210198839565f8d40a6b897beac8669cf7ba629051",
       "transactionIndex": 23,
-      "hash": "QmWd5PH6vyRH5kMdzZRPBnf952dbR4av3Bd7B2wBqMaAcf"
+      "anchorFileHash": "QmWd5PH6vyRH5kMdzZRPBnf952dbR4av3Bd7B2wBqMaAcf"
     },
     {
       "blockNumber": 545237,
       "blockHash": "0000000000000000001bfd6c48a6c3e81902cac688e12c2d87ca3aca50e03fb5",
       "transactionIndex": 333,
-      "hash": "QmbJGU4wNti6vNMGMosXaHbeMHGu9PkAUZtVBb2s2Vyq5d"
+      "anchorFileHash": "QmbJGU4wNti6vNMGMosXaHbeMHGu9PkAUZtVBb2s2Vyq5d"
     }
   ]
 }
 ```
 
 
-## Write a Sidetree anchor file hash
-Writes a Sidetree anchor file hash to the underlying blockchain.
+## Write a Sidetree transaction
+Writes a Sidetree transaction to the underlying blockchain.
 
 |                     |      |
 | ------------------- | ---- |
@@ -385,7 +384,7 @@ Writes a Sidetree anchor file hash to the underlying blockchain.
 
 ### Request path
 ```
-POST /<api-version>/
+POST /<api-version>/transaction/
 ```
 
 ### Request headers
@@ -402,7 +401,7 @@ POST /<api-version>/
 
 ### Request example
 ```
-POST /v1.0/
+POST /v1.0/transaction/
 ```
 ```json
 {

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -344,8 +344,10 @@ GET /v1.0/
   "hasMoreHashes": "True if there are more hashes beyond the returned batch of hashes. False otherwise.",
   "anchorFileHashes": [
     {
-      "confirmationTime": "The timestamp in ISO 8601 format 'YYYY-MM-DDThh:mm:ssZ' indicating when this hash was
-        anchored to the blockchain.",
+      "blockNumber": "The block number of the block that contains the anchor file hash. Used for ordering.",
+      "blockHash": "A hash of the block that contains the anchor file hash.",
+      "transactionIndex": "The index to this transaction among all the transactions in the block.
+                           Used to order multiple Sidetree transactions in the same block.",
       "hash": "Hash of the anchor file."
     }
   ]
@@ -358,11 +360,15 @@ GET /v1.0/
   "hasMoreHashes": false,  
   "anchorFileHashes": [
     {
-      "confirmationTime": "2018-09-13T19:20:30Z",
+      "blockNumber": 545236,
+      "blockHash": "0000000000000000002443210198839565f8d40a6b897beac8669cf7ba629051",
+      "transactionIndex": 23,
       "hash": "QmWd5PH6vyRH5kMdzZRPBnf952dbR4av3Bd7B2wBqMaAcf"
     },
     {
-      "confirmationTime": "2018-09-13T20:00:00Z",
+      "blockNumber": 545237,
+      "blockHash": "0000000000000000001bfd6c48a6c3e81902cac688e12c2d87ca3aca50e03fb5",
+      "transactionIndex": 333,
       "hash": "QmbJGU4wNti6vNMGMosXaHbeMHGu9PkAUZtVBb2s2Vyq5d"
     }
   ]
@@ -408,8 +414,8 @@ POST /v1.0/
 None.
 
 
-## Get block confirmation time
-Gets the block confirmation time in UTC of the block identified by the given block hash.
+## Get block
+Gets the data of a block identified by the block hash.
 
 |                     |      |
 | ------------------- | ---- |
@@ -417,7 +423,7 @@ Gets the block confirmation time in UTC of the block identified by the given blo
 
 ### Request path
 ```
-GET /<api-version>/confirmation-time/<block-hash>
+GET /<api-version>/block/<block-hash>
 ```
 
 ### Request headers
@@ -428,21 +434,22 @@ None.
 
 ### Request example
 ```
-Get /v1.0/confirmation-time/QmbJGU4wNti6vNMGMosXaHbeMHGu9PkAUZtVBb2s2Vyq5d
+Get /v1.0/block/0000000000000000001bfd6c48a6c3e81902cac688e12c2d87ca3aca50e03fb5
 ```
 
 ### Response body schema
 ```json
 {
-  "confirmationTime": "The timestamp in ISO 8601 format 'YYYY-MM-DDThh:mm:ssZ' indicating when the block was
-                       confirmed on blockchain."
+  "blockNumber": "The block number.",
+  "blockHash": "The block hash, should be the same as the value given in query path."
 }
 ```
 
 ### Response body example
 ```json
 {
-  "confirmationTime": "2018-09-13T19:20:30Z",
+  "blockNumber": 545236,
+  "blockHash": "0000000000000000002443210198839565f8d40a6b897beac8669cf7ba629051"
 }
 ```
 
@@ -458,7 +465,7 @@ Gets the hash of the last confirmed block.
 
 ### Request path
 ```
-GET /<api-version>/block-hash/last
+GET /<api-version>/block/last
 ```
 
 ### Request headers
@@ -469,13 +476,22 @@ None.
 
 ### Request example
 ```
-Get /v1.0/block-hash/last
+Get /v1.0/block/last
 ```
 
 ### Response body schema
 ```json
 {
-  "blockHash": "The hash of the last confirmed block."
+  "blockNumber": "The block number of the last known block.",
+  "blockHash": "The block hash of the last known block."
+}
+```
+
+### Response body example
+```json
+{
+  "blockNumber": 545236,
+  "blockHash": "0000000000000000002443210198839565f8d40a6b897beac8669cf7ba629051"
 }
 ```
 

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -29,7 +29,7 @@ Under normal processing, the _observer_ would process operations in chronologica
 
 It is useful to view the operations as producing a collection of version *chains* one per DID. Each create operation introduces a new chain and each update operation adds an edge to an existing chain. There could be holes in the chain if some historical update is missing - as noted above, this could be caused due to CAS delays.
 
-When two update operations reference the same (prior) version of a DID document, the cache removes from consideration the later of the two operations and all operations directly and indirectly referencing the removed operation. This ensures that the document versions of a particular DID form a chain without any forks. For illustration, assume we have recorded four operations for a particular DID producing the following chain:
+When two update operations reference the same (prior) version of a DID Document, the cache removes from consideration the later of the two operations and all operations directly and indirectly referencing the removed operation. This ensures that the document versions of a particular DID form a chain without any forks. For illustration, assume we have recorded four operations for a particular DID producing the following chain:
 ```
 v0 -> v1 -> v2 -> v3
 ```
@@ -53,7 +53,7 @@ The effect of this method is to delete the effects of any operation added with a
 
 ## Lookup
 
-This method looks up the DID document given an _operation hash_.
+This method looks up the DID Document given an _operation hash_.
 
 ```javascript
 public lookup(operationHash: Buffer): DidDocument

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -136,22 +136,21 @@ The _anchor file_ is a JSON document of the following schema:
 }
 ```
 
-# Sidetree Entity Operations
+# Sidetree Operations
 
-> TODO: Entire section pending review and update.
+> TODO: Entire section pending update.
 
-Sidetree Entities are a form of [Decentralized Identifier](https://w3c-ccg.github.io/did-spec/) (DID) that manifest through blockchain-anchoring DID Document objects (and subsequent deltas) that represent the existence and state of entities. A _Sidetree node exposes a REST API using which an external application can create a new DID with an initial DID Document, update the DID Document, lookup (resolve ) the DID Document for a DID, and delete the Document.
 
 ## DID Documents
 
 > TODO: to be updated.
 
- An update to a DID document is specified as a [JSON patch](https://tools.ietf.org/html/rfc6902) and is authenticated with a signature using the DID owner's private key. The sequence of updates to a DID document produces a sequence of _versions_ of the document. Each update to an entity references the previous update (creation, update, recovery, etc.) forming a chain of change history. Ownership of an Entity is linked to possession of keys specified within the Entity object itself.
+ An update to a DID document is specified as a [JSON patch](https://tools.ietf.org/html/rfc6902) and is authenticated with a signature using the DID owner's private key. The sequence of updates to a DID document produces a sequence of _versions_ of the document. Each update to a DID document references the previous update (creation, update, recovery, etc.) forming a chain of change history. Ownership of a DID is linked to possession of keys specified within the DID document itself.
 
-System diagram showing op sig links that form a Sidetree Entity Trail:
+System diagram showing operation chain of a DID:
 > TODO: Need to update this outdated diagram: 1. each operation only references the previous. 2. Only file hash is anchored on blockchain.
 
-![Sidetree Entity Trail diagram](./diagrams/sidetree-entity-trail.png)
+![Sidetree operation trail diagram](./diagrams/sidetree-entity-trail.png)
 
 
 ## Operation Hashes and DIDs
@@ -161,7 +160,7 @@ An _operation hash_ is the hash of the JSON-formated request of a state-modifyin
 A Sidetree DID is simply the DID method name suffixed with the _operation hash_ of a valid create operation request.
 
 # Sidetree REST API
-This section defines the `v1.0` version of the Sidetree DID REST API.
+A _Sidetree node_ expose a set of REST API that enables the creation of a new DID and its initial DID document, subsequent DID document updates, and DID document lookups. This section defines the `v1.0` version of the Sidetree DID REST API.
 
 ## Response HTTP status codes
 
@@ -492,11 +491,11 @@ As an early WIP, this protocol may require further additions and modifications a
 
 ## DDoS Mitigation
 
-Given the protocol was designed to enable unique Entity rooting and DPKI operations to be performed at 'unfair' volumes with unit costs that are 'unfairly' cheap, the single most credible issue for the system would be DDoS vectors.
+Given the protocol was designed to enable unique DID rooting and DPKI operations to be performed at 'unfair' volumes with unit costs that are 'unfairly' cheap, the single most credible issue for the system would be DDoS vectors.
 
-What does DDoS mean in this context? Because Entity IDs and subsequent operations in the system are represented via embedded tree structures where the trees can be arbitrarily large, it is possible for protocol adherent nodes to create and broadcast transactions to the underlying blockchain that embed massive sidetrees composed of leaves that are not intended for any other purpose than to force other observing nodes to process their Entity operations in accordance with the protocol.
+What does DDoS mean in this context? Because DIDs and subsequent operations in the system are represented via embedded tree structures where the trees can be arbitrarily large, it is possible for protocol adherent nodes to create and broadcast transactions to the underlying blockchain that embed massive sidetrees composed of leaves that are not intended for any other purpose than to force other observing nodes to process their operations in accordance with the protocol.
 
-The critical questions are: can observing nodes 'outrun' bad actors who may seek to clog the system with transactions bearing spurious Sidetrees meant to degraded system-wide performance? Can an attacker generate spurious Sidetrees of Entity ops faster than observing nodes can fetch the Sidetree data and process the operations? Without actually running a simulation yet, it's important to consider what mitigations can be put in place to assure that, assuming an issue exists, it can be overcome.
+The critical questions are: can observing nodes 'outrun' bad actors who may seek to clog the system with transactions bearing spurious Sidetrees meant to degraded system-wide performance? Can an attacker generate spurious Sidetrees of operations faster than observing nodes can fetch the Sidetree data and process the operations? Without actually running a simulation yet, it's important to consider what mitigations can be put in place to assure that, assuming an issue exists, it can be overcome.
 
 At a certain point, the attacker would be required to overwhelm the underlying chain itself, which has its own in-built organic price-defense, but it's possible that the Layer 2 nodes can be overcome before that begins to impact the attacker.
 
@@ -506,7 +505,7 @@ At a certain point, the attacker would be required to overwhelm the underlying c
 
 A very basic idea is to simply limit the depth of a protocol-adherent sidetree. The protocol could specify that Sidetrees that exceed a maximum depth are discarded, which would limit the ability of all participants to drop massive trees on the system. At its core, this mitigation strategy forces the attacker to deal with the organic economic pressure exerted by the underlying chain's transactional unit cost.
 
-> NOTE: large block expansion of the underlying chain generally creates a Tragedy of the Commons spam condition on the chain itself, which negatively impacts this entire class of DDoS protection for all L2 systems. Large block expansion may exclude networks from being a viable substrate for Sidetree Entities, if this mitigation strategy was selected for use.
+> NOTE: large block expansion of the underlying chain generally creates a Tragedy of the Commons spam condition on the chain itself, which negatively impacts this entire class of DDoS protection for all L2 systems. Large block expansion may exclude networks from being a viable substrate for Sidetree, if this mitigation strategy was selected for use.
 
 #### Transaction & Leaf-level Proof-of-Work
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -26,7 +26,7 @@ Architecturally, a Sidetree network is a network consists of multiple logical se
 
 ## Format and Encoding
 * JSON is used as the data encapsulation format.
-* Base64URL encoding is use whenever encoding is needed for binary data or cryptographic consistency.
+* Base58 encoding is use whenever encoding is needed for binary data or cryptographic consistency.
 * [_Multihash_] is used to represent hashes.
 
 # Sidetree Protocol Parameters
@@ -50,7 +50,7 @@ Since Sidetree batches many operations using a Merkle tree, each operation can b
 {
   "receipt": [
     {
-      "hash": "base64url encoded value of a Merkle tree node hash.",
+      "hash": "A Merkle tree node hash.",
       "side": "Must be 'left' or 'right', denotes the position of this hash."
     },
     ...
@@ -119,8 +119,8 @@ The _batch file_ is a ZIP compressed JSON document of the following schema:
 ```json
 {
   "operations": [
-    "Base64URL encoded operation",
-    "Base64URL encoded operation",
+    "Base58 encoded operation",
+    "Base58 encoded operation",
     ...
   ]
 }
@@ -130,8 +130,8 @@ The _batch file_ is a ZIP compressed JSON document of the following schema:
 The _anchor file_ is a JSON document of the following schema:
 ```json
 {
-  "batchFile": "Base64URL encoded hash of the batch file.",
-  "merkleRoot": "Base64URL encoded root hash of the Merkle tree contructed using the batch file."
+  "batchFile": "Base58 encoded hash of the batch file.",
+  "merkleRoot": "Base58 encoded root hash of the Merkle tree contructed using the batch file."
 }
 ```
 
@@ -155,7 +155,7 @@ System diagram showing op sig links that form a Sidetree Entity Trail:
 
 ## DIDs and Document Version URLs
 
-All state-modifying Sidetree operations (Create, Update, and Delete), upon successful completion, return as output a _version URL_ that serves as a unique handle identifying the version of the DID document produced by the operation; the handle is used as input parameters of future operations as discussed below. A version URL is of the form **did:stree:Hash** where *Hash* represents a Base64URL encoded multihash value. The version URL is an emergent value derived from anchoring the update operation in the blockchain as described in [Section](#creation-of-a-sidetree-entity).
+All state-modifying Sidetree operations (Create, Update, and Delete), upon successful completion, return as output a _version URL_ that serves as a unique handle identifying the version of the DID document produced by the operation; the handle is used as input parameters of future operations as discussed below. A version URL is of the form **did:stree:Hash** where *Hash* represents a Base58 encoded multihash value. The version URL is an emergent value derived from anchoring the update operation in the blockchain as described in [Section](#creation-of-a-sidetree-entity).
 
 The version URL output by the Create operation defines the newly created decentralized id (DID). In other words, a DID is simply the URL of the first version of its document.
 
@@ -206,8 +206,8 @@ POST /<api-version>/
 ```json
 {
   "signingKeyId": "ID of the key used to sign the initial didDocument.",
-  "createPayload": "Base64URL encoded initial DID Document of the DID.",
-  "signature": "Base64URL encoded signature of the payload signed by the private-key corresponding to the
+  "createPayload": "Base58 encoded initial DID Document of the DID.",
+  "signature": "Base58 encoded signature of the payload signed by the private-key corresponding to the
     public-key specified by the signingKeyId.",
   "proofOfWork": "Optional. If not given, the Sidetree node must perform proof-of-work on the requester's behalf
     or reject the request."
@@ -349,8 +349,8 @@ POST /<api-version>/
 ```json
 {
   "signingKeyId": "ID of the key used to sign the update payload",
-  "updatePayload": "Base64URL encoded update payload JSON object define by the schema below.",
-  "signature": "Base64URL encoded signature of the payload signed by the private-key corresponding to the
+  "updatePayload": "Base58 encoded update payload JSON object define by the schema below.",
+  "signature": "Base58 encoded signature of the payload signed by the private-key corresponding to the
     public-key specified by the signingKeyId.",
   "proofOfWork": "Optional. If not given, the Sidetree node must perform proof-of-work on the requester's behalf
     or reject the request."
@@ -370,9 +370,9 @@ POST /<api-version>/
 ### Update payload schema example
 ```json
 {
-  "did": "did:sidetree:exKwW0HjS5y4zBtJ7vYDwglYhtckdO15JDt1j5F5Q0A",
+  "did": "did:sidetree:QmWd5PH6vyRH5kMdzZRPBnf952dbR4av3Bd7B2wBqMaAcf",
   "operationNumber": 12,
-  "perviousOperationHash": "N-JQZifsEIzwZDVVrFnLRXKREIVTFhSFMC1pt08WFzI",
+  "perviousOperationHash": "QmbJGU4wNti6vNMGMosXaHbeMHGu9PkAUZtVBb2s2Vyq5d",
   "patch": {
     "op": "remove",
     "path": "/publicKey/0"
@@ -386,7 +386,7 @@ POST /v1.0/
 ```
 ```json
 {
-  "signingKeyId": "did:sidetree:exKwW0HjS5y4zBtJ7vYDwglYhtckdO15JDt1j5F5Q0A#key-1",
+  "signingKeyId": "did:sidetree:QmWd5PH6vyRH5kMdzZRPBnf952dbR4av3Bd7B2wBqMaAcf#key-1",
   "updatePayload": "...",
   "signature": "...",
   "proofOfWork": { ... }
@@ -414,8 +414,8 @@ POST /<api-version>/
 ```json
 {
   "signingKeyId": "ID of the key used to sign the update payload",
-  "deletePayload": "Base64URL encoded delete payload JSON object define by the schema below.",
-  "signature": "Base64URL encoded signature of the payload signed by the private-key corresponding to the
+  "deletePayload": "Base58 encoded delete payload JSON object define by the schema below.",
+  "signature": "Base58 encoded signature of the payload signed by the private-key corresponding to the
     public-key specified by the signingKeyId.",
   "proofOfWork": "Optional. If not given, the Sidetree node must perform proof-of-work on the requester's behalf
     or reject the request."
@@ -434,9 +434,9 @@ POST /<api-version>/
 ### Delete payload example
 ```json
 {
-  "did": "did:sidetree:exKwW0HjS5y4zBtJ7vYDwglYhtckdO15JDt1j5F5Q0A",
+  "did": "did:sidetree:QmWd5PH6vyRH5kMdzZRPBnf952dbR4av3Bd7B2wBqMaAcf",
   "operationNumber": 13,
-  "perviousOperationHash": "N-JQZifsEIzwZDVVrFnLRXKREIVTFhSFMC1pt08WFzI",
+  "perviousOperationHash": "QmbJGU4wNti6vNMGMosXaHbeMHGu9PkAUZtVBb2s2Vyq5d",
 }
 ```
 
@@ -446,7 +446,7 @@ POST /v1.0/
 ```
 ```json
 {
-  "signingKeyId": "did:sidetree:exKwW0HjS5y4zBtJ7vYDwglYhtckdO15JDt1j5F5Q0A#key-1",
+  "signingKeyId": "did:sidetree:QmWd5PH6vyRH5kMdzZRPBnf952dbR4av3Bd7B2wBqMaAcf#key-1",
   "updatePayload": "...",
   "signature": "...",
   "proofOfWork": { ... }

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -5,7 +5,7 @@ This document describes the specification of the Sidetree [_DID method_](https:/
 
 # Overview
 
-Using blockchains for anchoring and tracking unique, non-transferable, digital entities is a useful primitive, but the current strategies for doing so suffer from severely limited transactional performance constraints. Sidetree is a layer-2 protocol for anchoring and tracking _[DID documents](https://w3c-ccg.github.io/did-spec/)_ across a blockchain. The central design idea involves batching multiple _DID document_ operations into a single blockchain transaction. This allows Sidetree to inherit the immutability and verifiability guarantees of blockchain without being limited by its transaction rate.
+Using blockchains for anchoring and tracking unique, non-transferable, digital entities is a useful primitive, but the current strategies for doing so suffer from severely limited transactional performance constraints. Sidetree is a layer-2 protocol for anchoring and tracking _[DID Documents](https://w3c-ccg.github.io/did-spec/)_ across a blockchain. The central design idea involves batching multiple _DID Document_ operations into a single blockchain transaction. This allows Sidetree to inherit the immutability and verifiability guarantees of blockchain without being limited by its transaction rate.
 
 ![Sidetree System Overview](./diagrams/overview-diagram.png)
 
@@ -20,8 +20,8 @@ Architecturally, a Sidetree network is a network consists of multiple logical se
 | Batch file     | The file containing all the operation data batched together.                   |
 | CAS            | Same as DCAS.                                                                  |
 | DCAS           | Distributed content-addressable storage.                                       |
-| DID document   | A document containing metadata of a DID, as described by the [DID specification](https://w3c-ccg.github.io/did-spec/). |
-| Operation      | A change to a DID document.                                                    |
+| DID Document   | A document containing metadata of a DID, as described by the [DID specification](https://w3c-ccg.github.io/did-spec/). |
+| Operation      | A change to a DID Document.                                                    |
 | Operation hash | The hash of the JSON-formated request of a Sidetree operation.                 |
 | Sidetree node  | A logical server executing Sidetree protocol rules.                            |
 | Transaction    | A blockchain transaction representing a batch of Sidetree operations.          |
@@ -181,7 +181,7 @@ Sidetree protocol defines the following two mechanisms to prevent DDoS:
 
 
 # Sidetree REST API
-A _Sidetree node_ expose a set of REST API that enables the creation of a new DID and its initial DID document, subsequent DID document updates, and DID document lookups. This section defines the `v1.0` version of the Sidetree DID REST API.
+A _Sidetree node_ expose a set of REST API that enables the creation of a new DID and its initial DID Document, subsequent DID Document updates, and DID Document lookups. This section defines the `v1.0` version of the Sidetree DID REST API.
 
 ## Response HTTP status codes
 
@@ -236,7 +236,7 @@ In Sidetree implementation, certain properties or portion of which in teh initia
 * `id` - Ignored.
 * `publicKey\*\id` - DID portion is ignored.
 
-### Initial DID document example
+### Initial DID Document example
 ```json
 {
   "@context": "https://w3id.org/did/v1",
@@ -380,7 +380,7 @@ POST /<api-version>/
 {
   "did": "The DID to be updated",
   "operationNumber": "The number incremented from the last change version number. 1 if first change.",
-  "perviousOperationHash": "The hash of the previous operation made to the DID document.",
+  "perviousOperationHash": "The hash of the previous operation made to the DID Document.",
   "patch": "An RFC 6902 JSON patch to the current DID Document",
 }
 ```
@@ -445,7 +445,7 @@ POST /<api-version>/
 {
   "did": "The DID to be deleted",
   "operationNumber": "The number incremented from the last change version number. 1 if first change.",
-  "perviousOperationHash": "The hash of the previous operation made to the DID document."
+  "perviousOperationHash": "The hash of the previous operation made to the DID Document."
 }
 ```
 
@@ -482,7 +482,7 @@ where,
 -  RecoveryPatch: JSON patch specifying a new recovery public key. The patch can optionally identify old primary public key(s) and include new primary public key(s).
 -  Signature: Signature with the recovery secret key (corresponding to the recovery public key stored in the latest version associated with the DID).
 
-If the operation is successful, it applies the provided JSON patch to the version of the DID document identified.
+If the operation is successful, it applies the provided JSON patch to the version of the DID Document identified.
 
 > NOTE: The recovery patch must contain a fresh recovery public key. It is crucial to not release the recovery secret key, or to sign any predetermined message to prove its knowledge, a i.e., to have a non-replayable recovery mechanism. Otherwise, the system is exposed to man-in-the-middle vulnerability, where a malicious party can replace the new recovery public key in the recovery patch with her his own public key.
 > - The recovery key of a DID can only be rotated through a recover op. If the primary secret key is lost or compromised, the owner can change it to a new pair through Recover op. If the owner loses the recovery key, but still has access to her primary key, she can invoke the Delete op to delete her DID. However, if the owner’s recovery key gets compromised, then she loses complete control of her DID.


### PR DESCRIPTION
1. Implementation doc - Updated DID cache `apply` method description to support deterministic operation ordering.
1. Implementation doc - Updated blockchain REST API definition to be 'transaction' oriented.
1. Implementation doc - Updated Blockchain REST API definition to use block number as the ordering mechanism.
1. Implementation doc - Replaced all 'Base64' related references related to 'Base58' instead.'
1. Protocol doc - Updated the DDoS section with high-level proof-of-work description.
1. Protocol doc - Rewrote the Sidetree Operations and DIDs section.
1. Protocol doc - Removed/replaced all references to Sidetree 'entity'.
1. Protocol doc - Replaced all references of `version URL` with `operation hash`.
1. Protocol doc - Replaced all 'Base64' related references related to 'Base58' instead.'
1. Docs - Fixed casing of 'DID Document' to be consistent with DID spec.