### PR TITLE
Various DID Cache related fixes

### DIFF
--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -49,7 +49,7 @@ This method is used to handle rollbacks (forks) in the blockchain.
 public rollback (transactionNumber: number)
 ```
 
-The effect of this method is to delete the effects of any operation added with a *blockId* greater than the one provided.
+The effect of this method is to delete the effects of any operation included in a transaction with a transaction number greater than or equal to the _transactionNumber_ provided.
 
 ## Lookup
 

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -46,7 +46,7 @@ In the above description, *earlier* and *later* refer to the logical time of the
 This method is used to handle rollbacks (forks) in the blockchain.
 
 ```javascript
-public rollback(transactionNumber: number)
+public rollback (transactionNumber: number)
 ```
 
 The effect of this method is to delete the effects of any operation added with a *blockId* greater than the one provided.
@@ -56,7 +56,7 @@ The effect of this method is to delete the effects of any operation added with a
 This method looks up the DID Document given an _operation hash_.
 
 ```javascript
-public lookup(operationHash: Buffer): DidDocument
+public lookup (operationHash: Buffer): DidDocument
 ```
 
 If there is a missing update in the chain leading up to the provided `operationHash`, the method returns `null`.
@@ -66,10 +66,10 @@ If there is a missing update in the chain leading up to the provided `operationH
 These methods navigate the version chain.
 
 ```javascript
-public first(operationHash: Buffer): Buffer
-public last(operationHash: Buffer): Buffer
-public next(operationHash: Buffer): Buffer
-public prev(operationHash: Buffer): Buffer
+public first (operationHash: Buffer): Buffer
+public last (operationHash: Buffer): Buffer
+public next (operationHash: Buffer): Buffer
+public previous (operationHash: Buffer): Buffer
 ```
 
 ## Resolve

--- a/src/BatchFile.ts
+++ b/src/BatchFile.ts
@@ -16,7 +16,16 @@ export default class BatchFile {
     this.operations = operations;
   }
 
-  /** Converts this BatchFile into a JSON serialized buffer. */
+  /**
+   * Gets the decoded raw buffer representing the operation specified by the operationIndex.
+   */
+  public getOperationBuffer (operationIndex: number): Buffer {
+    return Buffer.from(Base58.decode(this.operations[operationIndex]));
+  }
+
+  /**
+   * Converts this BatchFile into a JSON serialized buffer.
+   */
   public toBuffer (): Buffer {
     return Buffer.from(JSON.stringify(this));
   }

--- a/src/BatchFile.ts
+++ b/src/BatchFile.ts
@@ -1,0 +1,65 @@
+import * as Base58 from 'bs58';
+
+/**
+ * Defines the schema of a Batch File and its related operations.
+ * NOTE: Must NOT add properties not defined by Sidetree protocol.
+ */
+export default class BatchFile {
+  /** Operations included in this BatchFile. */
+  public readonly operations: string[] = [];
+
+  /**
+   * BatchFile constructor.
+   * @param operations List of operations, each of which is a Base58 encoded string as specificied by the Sidetree protocol.
+   */
+  private constructor (operations: string[]) {
+    this.operations = operations;
+  }
+
+  /** Converts this BatchFile into a JSON serialized buffer. */
+  public toBuffer (): Buffer {
+    return Buffer.from(JSON.stringify(this));
+  }
+
+  /**
+   * Creates a BatchFile object from a batch file buffer.
+   */
+  public static fromBuffer (batchFileBuffer: Buffer): BatchFile {
+    const batchFileObject = JSON.parse(batchFileBuffer.toString());
+
+    // Ensure only properties specified by Sidetree protocol are given.
+    const allowedProperties = new Set(['operations']);
+    for (let property in batchFileObject) {
+      if (!allowedProperties.has(property)) {
+        throw new Error(`Unexpected property ${property} in batch file.`);
+      }
+    }
+
+    // Make sure operations is an array.
+    if (!(batchFileObject.operations instanceof Array)) {
+      throw new Error('Invalid batch file, operations property is not an array.');
+    }
+
+    // Make sure all operations are strings.
+    batchFileObject.operations.forEach((operation: any) => {
+      if (typeof operation !== 'string') {
+        throw new Error('Invalid batch file, operations property is not an array of strings.');
+      }
+    });
+
+    return new BatchFile(batchFileObject.operations);
+  }
+
+  /**
+   * Creates a BatchFile object an array of operation Buffers.
+   * @param operations Operation buffers in JSON serialized form, NOT encoded in anyway.
+   */
+  public static fromOperations (operations: Buffer[]): BatchFile {
+    const operationsBase58 = operations.map((operation) => {
+      return Base58.encode(operation);
+    });
+
+    return new BatchFile(operationsBase58);
+
+  }
+}

--- a/src/DidCache.ts
+++ b/src/DidCache.ts
@@ -83,7 +83,7 @@ export interface DidCache {
    * Return the previous version identifier of a given DID version
    * identifier. Return undefined if no such identifier is known.
    */
-  prev (versionId: VersionId): Promise<VersionId | undefined>;
+  previous (versionId: VersionId): Promise<VersionId | undefined>;
 
   /**
    * Return the next version identifier of a given DID version
@@ -275,7 +275,7 @@ class DidCacheImpl implements DidCache {
    * is inefficient and involves an async cas read. This should not be a problem
    * since this method is not hit for any of the externally exposed DID operations.
    */
-  public async prev (versionId: VersionId): Promise<VersionId | undefined> {
+  public async previous (versionId: VersionId): Promise<VersionId | undefined> {
     const opInfo = this.opHashToInfo.get(versionId);
     if (opInfo) {
       const op = await this.getOperation(opInfo);
@@ -305,7 +305,7 @@ class DidCacheImpl implements DidCache {
         return versionId;
       }
 
-      const prevVersionId = await this.prev(versionId);
+      const prevVersionId = await this.previous(versionId);
       if (prevVersionId === undefined) {
         return undefined;
       }

--- a/src/DidCache.ts
+++ b/src/DidCache.ts
@@ -141,6 +141,7 @@ class DidCacheImpl implements DidCache {
 
   /**
    * Apply (perform) a specified DID state changing operation.
+   * @returns Hash of the operation if the operation is applied successfully, undefined if the same operation was applied previously.
    */
   public apply (operation: WriteOperation): string | undefined {
     const opHash = DidCacheImpl.getHash(operation);

--- a/src/DidCache.ts
+++ b/src/DidCache.ts
@@ -295,21 +295,15 @@ class DidCacheImpl implements DidCache {
    * operations.
    */
   public async first (versionId: VersionId): Promise<VersionId | undefined> {
+    const opInfo = this.opHashToInfo.get(versionId);
+    if (opInfo === undefined) {
+      return undefined;
+    }
 
     while (true) {
-
-      const opInfo = this.opHashToInfo.get(versionId);
-      if (opInfo === undefined) {
-        return undefined;
-      }
-
-      if (this.isInitialVersion(opInfo)) {
-        return versionId;
-      }
-
       const prevVersionId = await this.previous(versionId);
       if (prevVersionId === undefined) {
-        return undefined;
+        return versionId;
       }
 
       versionId = prevVersionId;
@@ -329,16 +323,17 @@ class DidCacheImpl implements DidCache {
   }
 
   /**
-   * Return the latest (most recent) version of a DID document. Return undefined if
-   * the version is unknown.
+   * Returns the latest (most recent) version of a DID Document.
+   * Returns undefined if the version is unknown.
    */
   public async last (versionId: VersionId): Promise<VersionId | undefined> {
-    while (true) {
-      const opInfo = this.opHashToInfo.get(versionId);
-      if (opInfo === undefined) {
-        return undefined;
-      }
 
+    const opInfo = this.opHashToInfo.get(versionId);
+    if (opInfo === undefined) {
+      return undefined;
+    }
+
+    while (true) {
       const nextVersionId = await this.next(versionId);
       if (nextVersionId === undefined) {
         return versionId;

--- a/src/DidCache.ts
+++ b/src/DidCache.ts
@@ -1,4 +1,5 @@
 import * as Base58 from 'bs58';
+import BatchFile from './BatchFile';
 import Multihash from './Multihash';
 import Transaction from './Transaction';
 import { Cas } from './Cas';
@@ -395,10 +396,10 @@ class DidCacheImpl implements DidCache {
    */
   private async getOperation (opInfo: OperationInfo): Promise<WriteOperation> {
     const batchBuffer = await this.cas.read(opInfo.batchFileHash);
-    const batch = JSON.parse(batchBuffer.toString());
-    const opBuffer = Buffer.from(batch[opInfo.timestamp.operationIndex].data);
+    const batchFile = BatchFile.fromBuffer(batchBuffer);
+    const operationBuffer = batchFile.getOperationBuffer(opInfo.timestamp.operationIndex);
     return WriteOperation.create(
-      opBuffer,
+      operationBuffer,
       opInfo.batchFileHash,
       opInfo.timestamp.transactionNumber,
       opInfo.timestamp.operationIndex);

--- a/src/DidCache.ts
+++ b/src/DidCache.ts
@@ -232,7 +232,7 @@ class DidCacheImpl implements DidCache {
   public async resolve (did: VersionId): Promise<DidDocument | undefined> {
     const latestVersion = await this.last(did);
 
-    // lastVersion === null implies we do not know about the did
+    // lastVersion === undefined implies we do not know about the did
     if (latestVersion === undefined) {
       return undefined;
     }
@@ -315,7 +315,7 @@ class DidCacheImpl implements DidCache {
   }
 
   /**
-   * Return the next version of a DID document if it exists or null, otherwise.
+   * Return the next version of a DID document if it exists or undefined otherwise.
    */
   public async next (versionId: VersionId): Promise<VersionId | undefined> {
     const nextVersionId = this.nextVersion.get(versionId);
@@ -327,7 +327,7 @@ class DidCacheImpl implements DidCache {
   }
 
   /**
-   * Return the latest (most recent) version of a DID document. Return null if
+   * Return the latest (most recent) version of a DID document. Return undefined if
    * the version is unknown.
    */
   public async last (versionId: VersionId): Promise<VersionId | undefined> {

--- a/src/DidCache.ts
+++ b/src/DidCache.ts
@@ -95,7 +95,7 @@ export interface DidCache {
 
 /**
  * The timestamp of an operation. We define a linear ordering of
- * timestamps using the function lesser below.
+ * timestamps using the function earlier() below.
  */
 interface OperationTimestamp {
   readonly transactionNumber: number;
@@ -145,8 +145,8 @@ class DidCacheImpl implements DidCache {
   public apply (operation: WriteOperation): string | undefined {
     const opHash = DidCacheImpl.getHash(operation);
 
-    // Ignore operations without the required metadata - any operation anchored
-    // in a blockchain should have this metadata.
+    // Throw errors if missing any required metadata:
+    // any operation anchored in a blockchain must have this metadata.
     if (operation.transactionNumber === undefined) {
       throw Error('Invalid operation: transactionNumber undefined');
     }
@@ -177,7 +177,7 @@ class DidCacheImpl implements DidCache {
     // ignore this operation. Note that we might have a previous
     // operation with the same hash, but that previous operation
     // need not be earlier in timestamp order - hence the check
-    // with lesser().
+    // with earlier().
     const prevOperationInfo = this.opHashToInfo.get(opHash);
     if (prevOperationInfo !== undefined && earlier(prevOperationInfo.timestamp, opInfo.timestamp)) {
       return undefined;

--- a/src/DidCache.ts
+++ b/src/DidCache.ts
@@ -198,7 +198,7 @@ class DidCacheImpl implements DidCache {
 
   /**
    * Rollback the state of the DidCache by removing all operations
-   * with transactionNumber greater than the provided parameter value.
+   * with transactionNumber greater than or equal to the provided transaction number.
    * The intended use case for this method is to handle rollbacks
    * in the blockchain.
    *

--- a/src/Rooter.ts
+++ b/src/Rooter.ts
@@ -1,4 +1,5 @@
 import * as Deque from 'double-ended-queue';
+import BatchFile from './BatchFile';
 import MerkleTree from './lib/MerkleTree';
 import { getProtocol } from './Protocol';
 import { Blockchain } from './Blockchain';
@@ -59,8 +60,8 @@ export default class Rooter {
       const batch = await this.getBatch();
       console.info(Date.now() + ' Batch size = ' + batch.length);
 
-      // Combine all operations into one JSON buffer.
-      const batchBuffer = Buffer.from(JSON.stringify(batch));
+      // Combine all operations into a Batch File buffer.
+      const batchBuffer = BatchFile.fromOperations(batch).toBuffer();
 
       // TODO: Compress the batch buffer.
 

--- a/tests/DidCache.spec.ts
+++ b/tests/DidCache.spec.ts
@@ -2,29 +2,29 @@ import * as Base58 from 'bs58';
 import MockCas from './mocks/MockCas';
 import { Cas } from '../src/Cas';
 import { createDidCache } from '../src/DidCache';
-import { WriteOperation } from '../src/Operation'
+import { WriteOperation } from '../src/Operation';
 
 const didDocJson = {
-  "@context": "https://w3id.org/did/v1",
-  "id": "did:sidetree:ignored",
-  "publicKey": [{
-    "id": "did:sidetree:didPortionIgnored#key-1",
-    "type": "RsaVerificationKey2018",
-    "owner": "did:sidetree:ignoredUnlessResolvable",
-    "publicKeyPem": "-----BEGIN PUBLIC KEY...END PUBLIC KEY-----\r\n"
+  '@context': 'https://w3id.org/did/v1',
+  'id': 'did:sidetree:ignored',
+  'publicKey': [{
+    'id': 'did:sidetree:didPortionIgnored#key-1',
+    'type': 'RsaVerificationKey2018',
+    'owner': 'did:sidetree:ignoredUnlessResolvable',
+    'publicKeyPem': '-----BEGIN PUBLIC KEY...END PUBLIC KEY-----\r\n'
   }],
-  "service": [{
-    "type": "IdentityHub",
-    "publicKey": "did:sidetree:ignored#key-1",
-    "serviceEndpoint": {
-      "@context": "schema.identity.foundation/hub",
-      "@type": "UserServiceEndpoint",
-      "instances": ["did:bar:456", "did:zaz:789"]
+  'service': [{
+    'type': 'IdentityHub',
+    'publicKey': 'did:sidetree:ignored#key-1',
+    'serviceEndpoint': {
+      '@context': 'schema.identity.foundation/hub',
+      '@type': 'UserServiceEndpoint',
+      'instances': ['did:bar:456', 'did:zaz:789']
     }
   }]
 };
 
-function createCreateOperationBuffer(): Buffer {
+function createCreateOperationBuffer (): Buffer {
   const createPayload = Base58.encode(Buffer.from(JSON.stringify(didDocJson)));
   const createOpRequest = {
     createPayload,
@@ -34,7 +34,7 @@ function createCreateOperationBuffer(): Buffer {
   return Buffer.from(JSON.stringify(createOpRequest));
 }
 
-async function createOperationWithSingletonBatch(opBuf: Buffer, cas: Cas): Promise<WriteOperation> {
+async function createOperationWithSingletonBatch (opBuf: Buffer, cas: Cas): Promise<WriteOperation> {
   const batch: Buffer[] = [ opBuf ];
   const batchBuffer = Buffer.from(JSON.stringify(batch));
   const batchFileAddress = await cas.write(batchBuffer);
@@ -60,7 +60,7 @@ describe('DidCache', () => {
     expect(firstOfFirstVersion).toBe(firstVersion);
   });
 
-  it('should return firstVersion for last(firstVersion)', async() => {
+  it('should return firstVersion for last(firstVersion)', async () => {
     const cas = new MockCas();
     const didCache = createDidCache(cas);
     const createOp = await createOperationWithSingletonBatch(createCreateOperationBuffer(), cas);
@@ -68,7 +68,7 @@ describe('DidCache', () => {
     expect(await didCache.last(firstVersion)).toBe(firstVersion);
   });
 
-  it('should return undefined for prev(firstVersion)', async() => {
+  it('should return undefined for prev(firstVersion)', async () => {
     const cas = new MockCas();
     const didCache = createDidCache(cas);
     const createOp = await createOperationWithSingletonBatch(createCreateOperationBuffer(), cas);
@@ -82,7 +82,7 @@ describe('DidCache', () => {
     const didCache = createDidCache(cas);
     const createOp = await createOperationWithSingletonBatch(createCreateOperationBuffer(), cas);
     const firstVersion = didCache.apply(createOp) as string;
-    const resolvedDid = await didCache.resolve(firstVersion as string);
+    const resolvedDid = await didCache.resolve(firstVersion);
     // TODO: can we get the raw json from did? if so, we can write a better test.
     expect(resolvedDid).not.toBeUndefined();
   });

--- a/tests/DidCache.spec.ts
+++ b/tests/DidCache.spec.ts
@@ -29,47 +29,40 @@ async function addBatchOfOneOperation (opBuf: Buffer, cas: Cas): Promise<WriteOp
   return op;
 }
 
-describe('DidCache', () => {
+describe('DidCache', async () => {
+
+  let cas = new MockCas();
+  let didCache = createDidCache(cas);
+  let createOp;
+  let firstVersion: string | undefined;
+
+  beforeEach(async () => {
+    cas = new MockCas();
+    didCache = createDidCache(cas);
+    createOp = await addBatchOfOneOperation(createCreateOperationBuffer(), cas);
+    firstVersion = didCache.apply(createOp);
+  });
 
   it('should return operation hash for create op', async () => {
-    const cas = new MockCas();
-    const didCache = createDidCache(cas);
-    const createOp = await addBatchOfOneOperation(createCreateOperationBuffer(), cas);
-    expect(didCache.apply(createOp)).not.toBeUndefined();
+    expect(firstVersion).not.toBeUndefined();
   });
 
   it('should return firstVersion for first(firstVersion)', async () => {
-    const cas = new MockCas();
-    const didCache = createDidCache(cas);
-    const createOp = await addBatchOfOneOperation(createCreateOperationBuffer(), cas);
-    const firstVersion = didCache.apply(createOp) as string;
-    const firstOfFirstVersion = await didCache.first(firstVersion);
+    const firstOfFirstVersion = await didCache.first(firstVersion as string);
     expect(firstOfFirstVersion).toBe(firstVersion);
   });
 
-  it('should return onlyVersion for last(onlyVersion)', async () => {
-    const cas = new MockCas();
-    const didCache = createDidCache(cas);
-    const createOp = await addBatchOfOneOperation(createCreateOperationBuffer(), cas);
-    const onlyVersion = didCache.apply(createOp) as string;
-    expect(await didCache.last(onlyVersion)).toBe(onlyVersion);
+  it('should return firstVersion for last(firstVersion) if firstVersion is the only version', async () => {
+    expect(await didCache.last(firstVersion as string)).toBe(firstVersion as string);
   });
 
   it('should return undefined for prev(firstVersion)', async () => {
-    const cas = new MockCas();
-    const didCache = createDidCache(cas);
-    const createOp = await addBatchOfOneOperation(createCreateOperationBuffer(), cas);
-    const firstVersion = didCache.apply(createOp) as string;
-    const prev = await didCache.previous(firstVersion);
+    const prev = await didCache.previous(firstVersion as string);
     expect(prev).toBeUndefined();
   });
 
   it('should return provided document for resolve(firstVersion)', async () => {
-    const cas = new MockCas();
-    const didCache = createDidCache(cas);
-    const createOp = await addBatchOfOneOperation(createCreateOperationBuffer(), cas);
-    const firstVersion = didCache.apply(createOp) as string;
-    const resolvedDid = await didCache.resolve(firstVersion);
+    const resolvedDid = await didCache.resolve(firstVersion as string);
     // TODO: can we get the raw json from did? if so, we can write a better test.
     expect(resolvedDid).not.toBeUndefined();
   });

--- a/tests/DidCache.spec.ts
+++ b/tests/DidCache.spec.ts
@@ -44,11 +44,11 @@ async function createOperationWithSingletonBatch(opBuf: Buffer, cas: Cas): Promi
 
 describe('DidCache', () => {
 
-  it('should return non-null url for create op', async () => {
+  it('should return operation hash for create op', async () => {
     const cas = new MockCas();
     const didCache = createDidCache(cas);
     const createOp = await createOperationWithSingletonBatch(createCreateOperationBuffer(), cas);
-    expect(didCache.apply(createOp)).not.toBeNull();
+    expect(didCache.apply(createOp)).not.toBeUndefined();
   });
 
   it('should return firstVersion for first(firstVersion)', async () => {
@@ -84,6 +84,6 @@ describe('DidCache', () => {
     const firstVersion = didCache.apply(createOp) as string;
     const resolvedDid = await didCache.resolve(firstVersion as string);
     // TODO: can we get the raw json from did? if so, we can write a better test.
-    expect(resolvedDid).not.toBeNull();
+    expect(resolvedDid).not.toBeUndefined();
   });
 });

--- a/tests/DidCache.spec.ts
+++ b/tests/DidCache.spec.ts
@@ -2,30 +2,11 @@ import * as Base58 from 'bs58';
 import MockCas from './mocks/MockCas';
 import { Cas } from '../src/Cas';
 import { createDidCache } from '../src/DidCache';
+import { didDocumentJson } from './mocks/MockDidDocumentGenerator';
 import { WriteOperation } from '../src/Operation';
 
-const didDocJson = {
-  '@context': 'https://w3id.org/did/v1',
-  'id': 'did:sidetree:ignored',
-  'publicKey': [{
-    'id': 'did:sidetree:didPortionIgnored#key-1',
-    'type': 'RsaVerificationKey2018',
-    'owner': 'did:sidetree:ignoredUnlessResolvable',
-    'publicKeyPem': '-----BEGIN PUBLIC KEY...END PUBLIC KEY-----\r\n'
-  }],
-  'service': [{
-    'type': 'IdentityHub',
-    'publicKey': 'did:sidetree:ignored#key-1',
-    'serviceEndpoint': {
-      '@context': 'schema.identity.foundation/hub',
-      '@type': 'UserServiceEndpoint',
-      'instances': ['did:bar:456', 'did:zaz:789']
-    }
-  }]
-};
-
 function createCreateOperationBuffer (): Buffer {
-  const createPayload = Base58.encode(Buffer.from(JSON.stringify(didDocJson)));
+  const createPayload = Base58.encode(Buffer.from(JSON.stringify(didDocumentJson)));
   const createOpRequest = {
     createPayload,
     signature: 'signature',
@@ -60,12 +41,12 @@ describe('DidCache', () => {
     expect(firstOfFirstVersion).toBe(firstVersion);
   });
 
-  it('should return firstVersion for last(firstVersion)', async () => {
+  it('should return onlyVersion for last(onlyVersion)', async () => {
     const cas = new MockCas();
     const didCache = createDidCache(cas);
     const createOp = await createOperationWithSingletonBatch(createCreateOperationBuffer(), cas);
-    const firstVersion = didCache.apply(createOp) as string;
-    expect(await didCache.last(firstVersion)).toBe(firstVersion);
+    const onlyVersion = didCache.apply(createOp) as string;
+    expect(await didCache.last(onlyVersion)).toBe(onlyVersion);
   });
 
   it('should return undefined for prev(firstVersion)', async () => {

--- a/tests/DidCache.spec.ts
+++ b/tests/DidCache.spec.ts
@@ -54,7 +54,7 @@ describe('DidCache', () => {
     const didCache = createDidCache(cas);
     const createOp = await createOperationWithSingletonBatch(createCreateOperationBuffer(), cas);
     const firstVersion = didCache.apply(createOp) as string;
-    const prev = await didCache.prev(firstVersion);
+    const prev = await didCache.previous(firstVersion);
     expect(prev).toBeUndefined();
   });
 

--- a/tests/DidCache.spec.ts
+++ b/tests/DidCache.spec.ts
@@ -1,4 +1,5 @@
 import * as Base58 from 'bs58';
+import BatchFile from '../src/BatchFile';
 import MockCas from './mocks/MockCas';
 import { Cas } from '../src/Cas';
 import { createDidCache } from '../src/DidCache';
@@ -15,9 +16,14 @@ function createCreateOperationBuffer (): Buffer {
   return Buffer.from(JSON.stringify(createOpRequest));
 }
 
-async function createOperationWithSingletonBatch (opBuf: Buffer, cas: Cas): Promise<WriteOperation> {
-  const batch: Buffer[] = [ opBuf ];
-  const batchBuffer = Buffer.from(JSON.stringify(batch));
+/**
+ * Creates a batch file with single operation given operation buffer,
+ * then adds the batch file to the given CAS.
+ * @returns The operation in the batch file added in the form of a WriteOperation.
+ */
+async function addBatchOfOneOperation (opBuf: Buffer, cas: Cas): Promise<WriteOperation> {
+  const operations: Buffer[] = [ opBuf ];
+  const batchBuffer = BatchFile.fromOperations(operations).toBuffer();
   const batchFileAddress = await cas.write(batchBuffer);
   const op = WriteOperation.create(opBuf, batchFileAddress, 0, 0);
   return op;
@@ -28,14 +34,14 @@ describe('DidCache', () => {
   it('should return operation hash for create op', async () => {
     const cas = new MockCas();
     const didCache = createDidCache(cas);
-    const createOp = await createOperationWithSingletonBatch(createCreateOperationBuffer(), cas);
+    const createOp = await addBatchOfOneOperation(createCreateOperationBuffer(), cas);
     expect(didCache.apply(createOp)).not.toBeUndefined();
   });
 
   it('should return firstVersion for first(firstVersion)', async () => {
     const cas = new MockCas();
     const didCache = createDidCache(cas);
-    const createOp = await createOperationWithSingletonBatch(createCreateOperationBuffer(), cas);
+    const createOp = await addBatchOfOneOperation(createCreateOperationBuffer(), cas);
     const firstVersion = didCache.apply(createOp) as string;
     const firstOfFirstVersion = await didCache.first(firstVersion);
     expect(firstOfFirstVersion).toBe(firstVersion);
@@ -44,7 +50,7 @@ describe('DidCache', () => {
   it('should return onlyVersion for last(onlyVersion)', async () => {
     const cas = new MockCas();
     const didCache = createDidCache(cas);
-    const createOp = await createOperationWithSingletonBatch(createCreateOperationBuffer(), cas);
+    const createOp = await addBatchOfOneOperation(createCreateOperationBuffer(), cas);
     const onlyVersion = didCache.apply(createOp) as string;
     expect(await didCache.last(onlyVersion)).toBe(onlyVersion);
   });
@@ -52,7 +58,7 @@ describe('DidCache', () => {
   it('should return undefined for prev(firstVersion)', async () => {
     const cas = new MockCas();
     const didCache = createDidCache(cas);
-    const createOp = await createOperationWithSingletonBatch(createCreateOperationBuffer(), cas);
+    const createOp = await addBatchOfOneOperation(createCreateOperationBuffer(), cas);
     const firstVersion = didCache.apply(createOp) as string;
     const prev = await didCache.previous(firstVersion);
     expect(prev).toBeUndefined();
@@ -61,7 +67,7 @@ describe('DidCache', () => {
   it('should return provided document for resolve(firstVersion)', async () => {
     const cas = new MockCas();
     const didCache = createDidCache(cas);
-    const createOp = await createOperationWithSingletonBatch(createCreateOperationBuffer(), cas);
+    const createOp = await addBatchOfOneOperation(createCreateOperationBuffer(), cas);
     const firstVersion = didCache.apply(createOp) as string;
     const resolvedDid = await didCache.resolve(firstVersion);
     // TODO: can we get the raw json from did? if so, we can write a better test.

--- a/tests/RequestHandler.spec.ts
+++ b/tests/RequestHandler.spec.ts
@@ -1,3 +1,4 @@
+import BatchFile from '../src/BatchFile';
 import MockBlockchain from '../tests/mocks/MockBlockchain';
 import MockCas from '../tests/mocks/MockCas';
 import RequestHandler from '../src/RequestHandler';
@@ -43,6 +44,11 @@ describe('RequestHandler', () => {
     await rooter.rootOperations();
     expect(rooter.getOperationQueueLength()).toEqual(0);
     expect(blockchainWriteSpy).toHaveBeenCalledTimes(1);
+
+    // Verfiy that CAS was invoked to store the batch file.
+    const batchFileBuffer = await cas.read('0');
+    const batchFile = BatchFile.fromBuffer(batchFileBuffer);
+    expect(batchFile.operations.length).toEqual(1);
   });
 
   it('should return bad request if operation given is larger than protocol limit.', async () => {

--- a/tests/mocks/MockCas.ts
+++ b/tests/mocks/MockCas.ts
@@ -6,6 +6,7 @@ import { Cas } from '../../src/Cas';
  * returns the position of the array as address.
  */
 export default class MockCas implements Cas {
+  /** Anarray that stores the given content. */
   bufs: Buffer[] = [];
 
   public async write (content: Buffer): Promise<string> {

--- a/tests/mocks/MockDidCache.ts
+++ b/tests/mocks/MockDidCache.ts
@@ -35,7 +35,7 @@ export default class MockDidCache implements DidCache {
     return undefined;
   }
 
-  public async prev (_versionId: string): Promise<string | undefined> {
+  public async previous (_versionId: string): Promise<string | undefined> {
     return undefined;
   }
 

--- a/tests/mocks/MockDidDocumentGenerator.ts
+++ b/tests/mocks/MockDidDocumentGenerator.ts
@@ -8,7 +8,7 @@ export function didDocumentUpdate (didDoc: DidDocument, _operation: WriteOperati
   return didDoc;
 }
 
-const didDocJson = {
+export const didDocumentJson = {
   '@context': 'https://w3id.org/did/v1',
   'id': 'did:sidetree:ignored',
   'publicKey': [{
@@ -32,5 +32,5 @@ const didDocJson = {
  * Implementation of Did document create - return a dummy did document.
  */
 export function didDocumentCreate (_operation: WriteOperation): DidDocument {
-  return new DidDocument(didDocJson);
+  return new DidDocument(didDocumentJson);
 }

--- a/tests/mocks/MockDidDocumentGenerator.ts
+++ b/tests/mocks/MockDidDocumentGenerator.ts
@@ -1,32 +1,36 @@
 import { DidDocument } from '@decentralized-identity/did-common-typescript';
-import { WriteOperation } from '../../src/Operation'
+import { WriteOperation } from '../../src/Operation';
 
-// Implementation of Did document update - no-op for testing purposes
+/**
+ * Implementation of Did document update - no-op for testing purposes.
+ */
 export function didDocumentUpdate (didDoc: DidDocument, _operation: WriteOperation): DidDocument {
   return didDoc;
 }
 
 const didDocJson = {
-  "@context": "https://w3id.org/did/v1",
-  "id": "did:sidetree:ignored",
-  "publicKey": [{
-    "id": "did:sidetree:didPortionIgnored#key-1",
-    "type": "RsaVerificationKey2018",
-    "owner": "did:sidetree:ignoredUnlessResolvable",
-    "publicKeyPem": "-----BEGIN PUBLIC KEY...END PUBLIC KEY-----\r\n"
+  '@context': 'https://w3id.org/did/v1',
+  'id': 'did:sidetree:ignored',
+  'publicKey': [{
+    'id': 'did:sidetree:didPortionIgnored#key-1',
+    'type': 'RsaVerificationKey2018',
+    'owner': 'did:sidetree:ignoredUnlessResolvable',
+    'publicKeyPem': '-----BEGIN PUBLIC KEY...END PUBLIC KEY-----\r\n'
   }],
-  "service": [{
-    "type": "IdentityHub",
-    "publicKey": "did:sidetree:ignored#key-1",
-    "serviceEndpoint": {
-    "@context": "schema.identity.foundation/hub",
-    "@type": "UserServiceEndpoint",
-    "instances": ["did:bar:456", "did:zaz:789"]
+  'service': [{
+    'type': 'IdentityHub',
+    'publicKey': 'did:sidetree:ignored#key-1',
+    'serviceEndpoint': {
+      '@context': 'schema.identity.foundation/hub',
+      '@type': 'UserServiceEndpoint',
+      'instances': ['did:bar:456', 'did:zaz:789']
     }
   }]
 };
 
-// Implementation of Did document create - return a dummy did document
+/**
+ * Implementation of Did document create - return a dummy did document.
+ */
 export function didDocumentCreate (_operation: WriteOperation): DidDocument {
   return new DidDocument(didDocJson);
 }


### PR DESCRIPTION
DID Cache - Fixed a bug in first(...) and improved perf for first(...) and last(...)
DID Cache - Updated the rollback method description to match code.
DID Cache - Fixed all linter errors for tests.
DID Cache - Refactored tests to remove all code duplication.
DID Cache - Fixed obsolete references to lesser().
DID Cache - Updated batch file parsing to adhere to protocol schema + fixed tests.
DID Cache - Renamed method 'prev' to 'previous'.
DID Cache - Removed duplicated test DID Document.
DID Cache - Replaced all incorrect references to 'null' with 'undefined'.
Batch file - Added BatchFile class for parsing and validating batch files.
Rooter - Updated batch file creation to adhere to protocol schema + added test for it.