### PR TITLE
Various updates and fixes to enable Update REST API

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -62,7 +62,7 @@ An update to a DID Document is specified as a [_JSON patch_](https://tools.ietf.
 
 An _operation hash_ is the hash of the JSON-formatted request of a state-modifying Sidetree operation. The exact request schema for all operations are defined in [Sidetree REST API](#sidetree-rest-api) section. An _operation hash_ serves as a globally unique identifier of the operation, each write operation must reference the previous operation using the _operation hash_, forming a chain of change history.
 
-## Sidetree Operation DIDs
+## Sidetree DIDs
 
 A Sidetree DID is the hash of the DID Document given in the initial create operation as the create payload, prefixed by the Sidetree DID method name.
 
@@ -411,10 +411,10 @@ POST /<api-version>/
   "did": "did:sidetree:QmWd5PH6vyRH5kMdzZRPBnf952dbR4av3Bd7B2wBqMaAcf",
   "operationNumber": 12,
   "previousOperationHash": "QmbJGU4wNti6vNMGMosXaHbeMHGu9PkAUZtVBb2s2Vyq5d",
-  "patch": {
+  "patch": [{
     "op": "remove",
     "path": "/publicKey/0"
-  }
+  }]
 }
 ```
 
@@ -485,7 +485,7 @@ POST /v1.0/
 ```json
 {
   "signingKeyId": "did:sidetree:QmWd5PH6vyRH5kMdzZRPBnf952dbR4av3Bd7B2wBqMaAcf#key-1",
-  "updatePayload": "...",
+  "deletePayload": "...",
   "signature": "...",
   "proofOfWork": { ... }
 }
@@ -513,10 +513,10 @@ If the operation is successful, it applies the provided JSON patch to the versio
 
   Each write operation type have different payload schema.
 
-* Why use _block nubmer_ as the marker for protocol versioning change instead of the Sidetree _transaction number_?
-
-  Because _block nubmer_ increments irrespective of whether there are Sidetree activity or not, it makes protocol version upgrade planning and scheduling easier for Sidetree node that do not want to risk creating invalid transaction with obsolete version.
-
 * Why assign a _transaction number_ for invalid transactions?
 
   In the case of an _unresolvable transaction_, it is unknown if the transaction will be valid or not if it becomes resolvable, thus it is assigned a transaction number such that if the transaction turns out to be valid, the transaction number of existing valid transactions remain immutable. This also enables all Sidetree nodes to refer to the same transaction using the same transaction number.
+
+* Why is a request payload Base58 encoded?
+
+For the ease of implementation of signature verification code.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -513,10 +513,6 @@ If the operation is successful, it applies the provided JSON patch to the versio
 
   Each write operation type have different payload schema.
 
-* Why use _block number_ as the marker for protocol versioning change instead of the Sidetree _transaction number_?
-
-  Because _block number_ increments irrespective of whether there are Sidetree activity or not, it makes protocol version upgrade planning and scheduling easier for Sidetree node that do not want to risk creating invalid transaction with obsolete version.
-
 * Why assign a _transaction number_ for invalid transactions?
 
   In the case of an _unresolvable transaction_, it is unknown if the transaction will be valid or not if it becomes resolvable, thus it is assigned a transaction number such that if the transaction turns out to be valid, the transaction number of existing valid transactions remain immutable. This also enables all Sidetree nodes to refer to the same transaction using the same transaction number.

--- a/src/RequestHandler.ts
+++ b/src/RequestHandler.ts
@@ -83,8 +83,7 @@ export default class RequestHandler {
    * Handles resolve operation.
    */
   public async handleResolveRequest (did: string): Promise<Response> {
-    const didUniquePortion = did.substring(this.didMethodName.length);
-    const didDocument = await this.operationProcessor.resolve(didUniquePortion);
+    const didDocument = await this.operationProcessor.resolve(did);
 
     if (!didDocument) {
       return {
@@ -121,7 +120,7 @@ export default class RequestHandler {
     // TODO: Assert that operation is for sure a well-formed once the code reached here.
     // ie. Need to make sure invalid patch, missing operation number, patch etc will cause WriteOperation creation failure.
 
-    const updatedDidDocument = this.simulateUpdateOperation(operation);
+    const updatedDidDocument = await this.simulateUpdateOperation(operation);
 
     return {
       status: ResponseStatus.Succeeded,

--- a/tests/OperationProcessor.spec.ts
+++ b/tests/OperationProcessor.spec.ts
@@ -46,14 +46,16 @@ async function addBatchOfOneOperation (opBuf: Buffer, cas: Cas, transactionTime:
 
 describe('OperationProessor', async () => {
 
+  const didMethodName = 'did:sidetree:';
+
   let cas = new MockCas();
-  let operationProcessor = createOperationProcessor(cas, 'did:sidetree:');
+  let operationProcessor = createOperationProcessor(cas, didMethodName);
   let createOp;
   let firstVersion: string | undefined;
 
   beforeEach(async () => {
     cas = new MockCas();
-    operationProcessor = createOperationProcessor(cas, 'did:sidetree:'); // TODO: add a clear method to avoid double initialization.
+    operationProcessor = createOperationProcessor(cas, didMethodName); // TODO: add a clear method to avoid double initialization.
     createOp = await addBatchOfOneOperation(createCreateOperationBuffer(), cas, 0, 0);
     firstVersion = operationProcessor.process(createOp);
   });
@@ -76,10 +78,11 @@ describe('OperationProessor', async () => {
     expect(prev).toBeUndefined();
   });
 
-  it('should return provided document for resolve(firstVersion)', async () => {
-    const resolvedDid = await operationProcessor.resolve(firstVersion as string);
+  it('should return a DID Document for resolve(did) for a registered DID', async () => {
+    const did = `${didMethodName}${firstVersion!}`;
+    const didDocument = await operationProcessor.resolve(did);
     // TODO: can we get the raw json from did? if so, we can write a better test.
-    expect(resolvedDid).not.toBeUndefined();
+    expect(didDocument).not.toBeUndefined();
   });
 
   it('should process updates correctly', async () => {


### PR DESCRIPTION
Protocol doc - Fixed typos in Update and Delete REST API examples + other minor fixes.
Operation Processor - Updated resolve() to accept fully qualified DID as input.

With this change Update REST API is officially working.