### PR TITLE
Added support for SECP256K1 key in HEX format + a couple of critical bug fixes.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -444,6 +444,19 @@
       "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
       "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
     },
+    "bindings": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
+      "integrity": "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew=="
+    },
+    "bip66": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+      "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "bn.js": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz",
@@ -465,6 +478,19 @@
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
+    "browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "requires": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "bs58": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
@@ -472,6 +498,11 @@
       "requires": {
         "base-x": "^3.0.2"
       }
+    },
+    "buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -515,6 +546,15 @@
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
       "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
       "dev": true
+    },
+    "cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "cliui": {
       "version": "3.2.0",
@@ -689,6 +729,31 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "create-hash": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "requires": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "create-hmac": {
+      "version": "1.1.7",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "requires": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -770,6 +835,16 @@
       "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
       "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
     },
+    "drbg.js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
+      "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
+      "requires": {
+        "browserify-aes": "^1.0.6",
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4"
+      }
+    },
     "ec-key": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/ec-key/-/ec-key-0.0.2.tgz",
@@ -845,6 +920,15 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
+    },
+    "evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "requires": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
     },
     "execa": {
       "version": "0.7.0",
@@ -967,6 +1051,15 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
+    },
+    "hash-base": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+      "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "hash.js": {
       "version": "1.1.7",
@@ -1497,6 +1590,16 @@
       "integrity": "sha512-0Dab5btKVPhibSalc9QGXb559ED7G7iLjFXBaj9Wq8O3vorueR5K5jaE3hkG6ZQINyhA/JgG6Qk4qdFQjsYV6g==",
       "dev": true
     },
+    "md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -1591,6 +1694,11 @@
         "bs58": "^4.0.1",
         "varint": "^5.0.0"
       }
+    },
+    "nan": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
     },
     "negotiator": {
       "version": "0.6.1",
@@ -2912,6 +3020,15 @@
         "path-parse": "^1.0.5"
       }
     },
+    "ripemd160": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -2921,6 +3038,28 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "secp256k1": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.2.tgz",
+      "integrity": "sha512-iin3kojdybY6NArd+UFsoTuapOF7bnJNf2UbcWXaY3z+E1sJDipl60vtzB5hbO/uquBu7z0fd4VC4Irp+xoFVQ==",
+      "requires": {
+        "bindings": "^1.2.1",
+        "bip66": "^1.1.3",
+        "bn.js": "^4.11.3",
+        "create-hash": "^1.1.2",
+        "drbg.js": "^1.0.1",
+        "elliptic": "^6.2.3",
+        "nan": "^2.2.1",
+        "safe-buffer": "^5.1.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+        }
+      }
     },
     "semver": {
       "version": "5.5.0",
@@ -2938,6 +3077,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
       "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+    },
+    "sha.js": {
+      "version": "2.4.11",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "scripts": {
     "precommit": "npm run lint",
-    "build": "tsc && copyfiles json/*.json dist",
+    "build": "tsc && copyfiles json/*.json dist && copyfiles tests/json/*.json dist",
     "test": "jasmine-ts --config=./tests/jasmine.json",
     "cc": "npm run build && nyc jasmine --config=./tests/jasmine-cc.json",
     "lint": "tslint --fix --project .",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "linked-list-typescript": "^1.0.15",
     "multihashes": "^0.4.14",
     "node-fetch": "^2.3.0",
-    "raw-body": "^2.3.3"
+    "raw-body": "^2.3.3",
+    "secp256k1": "^3.5.2"
   },
   "devDependencies": {
     "@types/bs58": "^3.0.30",

--- a/src/Encoder.ts
+++ b/src/Encoder.ts
@@ -8,14 +8,16 @@ export default class Encoder {
    * Encodes given Buffer into a Base64URL string.
    */
   public static encode (content: Buffer | string): string {
-    return base64url.encode(content);
+    const encodedContent = base64url.encode(content);
+    return encodedContent;
   }
 
   /**
    * Decodes the given Base64URL string into a Buffer.
    */
   public static decodeAsBuffer (encodedContent: string): Buffer {
-    return Buffer.from(base64url.decode(encodedContent));
+    const content = base64url.toBuffer(encodedContent);
+    return content;
   }
 
   /**

--- a/src/lib/Did.ts
+++ b/src/lib/Did.ts
@@ -2,7 +2,7 @@ import Encoder from '../Encoder';
 import Multihash from '../Multihash';
 
 /**
- * Class reusable reusable DID related operations.
+ * Class containing reusable DID related operations.
  */
 export default class Did {
   /**

--- a/src/lib/DidPublicKey.ts
+++ b/src/lib/DidPublicKey.ts
@@ -1,0 +1,10 @@
+/**
+ * Interface representing a public key inside the 'publicKey' array property of a DID Document.
+ */
+export default interface DidPublicKey {
+  id: string;
+  type: string;
+  owner?: string;
+  publicKeyJwk?: any;
+  publicKeyHex?: string;
+}

--- a/tests/Operation.spec.ts
+++ b/tests/Operation.spec.ts
@@ -9,8 +9,8 @@ describe('WriteOperation', async () => {
   let createRequest: any;
 
   beforeAll(async () => {
-    const [publicKeyJwk, privateKeyJwk] = await Cryptography.generateKeyPair('key1'); // Generate a unique key-pair used for each test.
-    const createRequestBuffer = await OperationGenerator.generateCreateOperation(didDocumentTemplate, publicKeyJwk, privateKeyJwk);
+    const [publicKey, privateKey] = await Cryptography.generateKeyPairJwk('key1'); // Generate a unique key-pair used for each test.
+    const createRequestBuffer = await OperationGenerator.generateCreateOperation(didDocumentTemplate, publicKey, privateKey);
     createRequest = JSON.parse(createRequestBuffer.toString());
   });
 

--- a/tests/RequestHandler.spec.ts
+++ b/tests/RequestHandler.spec.ts
@@ -1,6 +1,7 @@
 import BatchFile from '../src/BatchFile';
 import Cryptography from '../src/lib/Cryptography';
 import Did from '../src/lib/Did';
+import DidPublicKey from '../src/lib/DidPublicKey';
 import Logger from '../src/lib/Logger';
 import MockBlockchain from '../tests/mocks/MockBlockchain';
 import MockCas from '../tests/mocks/MockCas';
@@ -32,8 +33,8 @@ describe('RequestHandler', () => {
   let operationProcessor;
   let requestHandler: RequestHandler;
 
-  let publicKeyJwk: any;
-  let privateKeyJwk: any;
+  let publicKey: DidPublicKey;
+  let privateKey: any;
   let did: string; // This DID is created at the beginning of every test.
   let batchFileHash: string;
 
@@ -52,8 +53,8 @@ describe('RequestHandler', () => {
 
     blockchain.setLatestTime(mockLatestTime);
 
-    [publicKeyJwk, privateKeyJwk] = await Cryptography.generateKeyPair('key1'); // Generate a unique key-pair used for each test.
-    const createOperationBuffer = await OperationGenerator.generateCreateOperation(didDocumentTemplate, publicKeyJwk, privateKeyJwk);
+    [publicKey, privateKey] = await Cryptography.generateKeyPairHex('key1'); // Generate a unique key-pair used for each test.
+    const createOperationBuffer = await OperationGenerator.generateCreateOperation(didDocumentTemplate, publicKey, privateKey);
 
     await requestHandler.handleWriteRequest(createOperationBuffer);
     await rooter.rootOperations();
@@ -109,7 +110,7 @@ describe('RequestHandler', () => {
 
     blockchain.setLatestTime(blockchainTime);
 
-    const createRequest = await OperationGenerator.generateCreateOperation(didDocumentTemplate, publicKeyJwk, privateKeyJwk);
+    const createRequest = await OperationGenerator.generateCreateOperation(didDocumentTemplate, publicKey, privateKey);
     const response = await requestHandler.handleWriteRequest(createRequest);
     const httpStatus = toHttpStatus(response.status);
 
@@ -166,7 +167,7 @@ describe('RequestHandler', () => {
       previousOperationHash: Did.getUniquePortion(did)
     };
 
-    const request = await OperationGenerator.generateUpdateOperation(updatePayload, privateKeyJwk);
+    const request = await OperationGenerator.generateUpdateOperation(updatePayload, publicKey.id, privateKey);
     const response = await requestHandler.handleWriteRequest(request);
     const httpStatus = toHttpStatus(response.status);
 
@@ -191,7 +192,7 @@ describe('RequestHandler', () => {
       previousOperationHash: Did.getUniquePortion(did)
     };
 
-    const request = await OperationGenerator.generateUpdateOperation(updatePayload, privateKeyJwk);
+    const request = await OperationGenerator.generateUpdateOperation(updatePayload, publicKey.id, privateKey);
     const response = await requestHandler.handleWriteRequest(request);
     const httpStatus = toHttpStatus(response.status);
 

--- a/tests/generators/OperationGenerator.ts
+++ b/tests/generators/OperationGenerator.ts
@@ -1,5 +1,7 @@
 import Cryptography from '../../src/lib/Cryptography';
+import DidPublicKey from '../../src/lib/DidPublicKey';
 import Encoder from '../../src/Encoder';
+import { PrivateKey } from '@decentralized-identity/did-auth-jose';
 
 /**
  * A class that can generate valid write operations.
@@ -11,19 +13,19 @@ export default class OperationGenerator {
    * Creates a Create Operation with valid signature.
    * @param didDocumentTemplate A DID Document used as the template. Must contain at least one public-key.
    */
-  public static async generateCreateOperation (didDocumentTemplate: any, publicKeyJwk: any, privateKeyJwk: any): Promise<Buffer> {
+  public static async generateCreateOperation (didDocumentTemplate: any, publicKey: DidPublicKey, privateKey: string | PrivateKey): Promise<Buffer> {
     // Replace the placeholder public-key with the public-key given.
-    didDocumentTemplate.publicKey[0].publicKeyJwk = publicKeyJwk;
+    didDocumentTemplate.publicKey[0] = publicKey;
 
     // Create the create payload.
     const didDocumentJson = JSON.stringify(didDocumentTemplate);
     const createPayload = Encoder.encode(didDocumentJson);
 
     // Generate the signature.
-    const signature = await Cryptography.sign(createPayload, privateKeyJwk);
+    const signature = await Cryptography.sign(createPayload, privateKey);
 
     const operation = {
-      signingKeyId: publicKeyJwk.kid,
+      signingKeyId: publicKey.id,
       createPayload,
       signature,
       proofOfWork: 'proof of work'
@@ -35,16 +37,16 @@ export default class OperationGenerator {
   /**
    * Generates an Update Operation with valid signature.
    */
-  public static async generateUpdateOperation (updatePayload: object, privateKeyJwk: any): Promise<Buffer> {
+  public static async generateUpdateOperation (updatePayload: object, keyId: string, privateKey: string | PrivateKey): Promise<Buffer> {
     // Encode Update payload.
     const updatePayloadJson = JSON.stringify(updatePayload);
     const updatePayloadEncoded = Encoder.encode(updatePayloadJson);
 
     // Generate the signature.
-    const signature = await Cryptography.sign(updatePayloadEncoded, privateKeyJwk);
+    const signature = await Cryptography.sign(updatePayloadEncoded, privateKey);
 
     const operation = {
-      signingKeyId: privateKeyJwk.kid,
+      signingKeyId: keyId,
       updatePayload: updatePayloadEncoded,
       signature,
       proofOfWork: 'proof of work'

--- a/tests/generators/VegetaLoadGenerator.ts
+++ b/tests/generators/VegetaLoadGenerator.ts
@@ -22,6 +22,7 @@ export default class VegetaLoadGenerator {
   public static async generateLoadFiles (uniqueDidCount: number, endpointUrl: string, absoluteFolderPath: string) {
 
     const didDocumentTemplate = require('../../../tests/json/didDocumentTemplate.json');
+    const keyId = 'key1';
 
     // Make directories needed by the request generator.
     fs.mkdirSync(absoluteFolderPath);
@@ -30,7 +31,7 @@ export default class VegetaLoadGenerator {
 
     for (let i = 0; i < uniqueDidCount; i++) {
       // Generate a random pair of public-private key pair and save them on disk.
-      const [publicKey, privateKey] = await Cryptography.generateKeyPair('key1'); // Generate a unique key-pair used for each test.
+      const [publicKey, privateKey] = await Cryptography.generateKeyPairHex(keyId); // Generate a unique key-pair used for each test.
       fs.writeFileSync(absoluteFolderPath + `/keys/privateKey${i}.json`, JSON.stringify(privateKey));
       fs.writeFileSync(absoluteFolderPath + `/keys/publicKey${i}.json`, JSON.stringify(publicKey));
 
@@ -61,7 +62,7 @@ export default class VegetaLoadGenerator {
       };
 
       // Generate an Update request body and save it on disk.
-      const updateOperationBuffer = await OperationGenerator.generateUpdateOperation(updatePayload, privateKey);
+      const updateOperationBuffer = await OperationGenerator.generateUpdateOperation(updatePayload, keyId, privateKey);
       fs.writeFileSync(absoluteFolderPath + `/requests/update${i}.json`, updateOperationBuffer);
     }
 


### PR DESCRIPTION
- Signature verification - Added support for SECP256K1 key in HEX format. This was mainly added because the implementation of this signature verification library is multiple times faster than `EcKey`. In longer term, JWK support should switch over to the `secp256k1` implementation also if possible.
 - Encoder - Fixed a bug where decodeAsBuffer was not decoding correctly.
 - CAS client - Fixed a bug where files larger than 64KB gets truncated when fetching.