### PR TITLE
Arvind/prep persistence

### DIFF
--- a/src/OperationProcessor.ts
+++ b/src/OperationProcessor.ts
@@ -1,69 +1,11 @@
 import * as Protocol from './Protocol';
+import { Cas } from '../src/Cas';
 import Cryptography from './lib/Cryptography';
 import DidPublicKey from './lib/DidPublicKey';
 import Document from './lib/Document';
-import { Cas } from './Cas';
 import { DidDocument } from '@decentralized-identity/did-common-typescript';
-import { LinkedList } from 'linked-list-typescript';
-import { getOperationHash, WriteOperation, OperationType } from './Operation';
-import { OperationStore } from './OperationStore';
-
-/**
- * Each operation that is submitted to OperationProcessor for processing
- * has one of the following status at any given point.
- *
- * Terminology useful for various comments below:
- *
- * Parent/Prev: For a non-create operation o this refers to the previous operation (version)
- * specified by o.
- * Ancestor: Transitive closure of the Parent relation.
- * Descendant: Inverse of Ancestor
- * Known Ancestry/Complete Ancestry: A predicate/property of an operation that indicates whether all the
- * ancestors of the operation are known (by the OperationProcessor).
- * Siblings: Two or more operations that point to the same parent.
- */
-enum OperationStatus {
-  /**
-   * An operation is in Unvalidated state if its ancestry is incomplete.
-   */
-  Unvalidated,
-
-  /**
-   * An operation is in Valid state if all the following conditions hold:
-   * (1) It's ancestry is complete
-   * (2) Validation checks such as signature verification pass
-   * (3) It is the earliest sibling in terms of its timestamp (see earliest interface below).
-   */
-  Valid,
-
-  /**
-   * An operation is in Invalid state if its ancestry is complete but at least one of the three conditions
-   * above is false.
-   */
-  Invalid
-}
-
-/**
- * VersionId identifies the version of a DID document. We use the hash of the
- * operation that produces a particular version of a DID document as its versionId.
- * This usage is guaranteed to produce unique VersionId's since the operation contains
- * as one of its properties the previous VersionId. Since the operation hash is
- * just a string we alias VersionId to string.
- *
- * With this usage, the operation hash serves two roles (1) an identifier for an operation
- * (2) an identifier for the DID document produced by the operation. In the code below,
- * we always use VersionId in places where we mean (2) and an OperationHash defined below
- * when we mean (1).
- *
- * Since we identify versions using the operation it is meaningful to apply OperationStatus
- * to versions.
- */
-export type VersionId = string;
-
-/**
- * Alias OperationHash to string - see comment above
- */
-export type OperationHash = string;
+import { WriteOperation, OperationType } from './Operation';
+import { createOperationStore, OperationStore } from './OperationStore';
 
 /**
  * Represents the interface used by other components to process DID operations
@@ -78,11 +20,11 @@ export interface OperationProcessor {
    * operation.
    * @returns the hash of the operation.
    */
-  process (operation: WriteOperation): Promise<string>;
+  process (operation: WriteOperation): Promise<void>;
 
   /**
    * Remove all previously processed operations with transactionNumber
-   * greater than the provided parameter value.
+   * greater or equal to the provided parameter value.
    * The intended use case for this method is to handle rollbacks
    * in the blockchain.
    */
@@ -92,69 +34,6 @@ export interface OperationProcessor {
    * Resolve a did.
    */
   resolve (did: string): Promise<DidDocument | undefined>;
-
-  /**
-   * Returns the Did document for a given version identifier.
-   */
-  lookup (versionId: VersionId): Promise<DidDocument | undefined>;
-
-  /**
-   * Return the first (initial) version identifier given
-   * version identifier, which is also the DID for the
-   * document corresponding to the versions. Return undefined
-   * if the version id or some previous version in the chain
-   * is unknown.
-   */
-  first (versionId: VersionId): Promise<VersionId | undefined>;
-
-  /**
-   * Return the last (latest/most recent) version identifier of
-   * a given version identifier. Return undefined if the version
-   * identifier is unknown or some successor identifier is unknown.
-   */
-  last (versionId: VersionId): Promise<VersionId | undefined>;
-
-  /**
-   * Return the previous version identifier of a given DID version
-   * identifier. Return undefined if no such identifier is known.
-   */
-  previous (versionId: VersionId): Promise<VersionId | undefined>;
-
-  /**
-   * Return the next version identifier of a given DID version
-   * identifier. Return undefined if no such identifier is known.
-   */
-  next (versionId: VersionId): Promise<VersionId | undefined>;
-}
-
-/**
- * The timestamp of an operation. We define a linear ordering of
- * timestamps using the function earlier() below.
- * TODO: Consider consolidating this modal interface with ResolvedTransaction.
- */
-interface OperationTimestamp {
-  readonly transactionNumber: number;
-  readonly operationIndex: number;
-}
-
-function earlier (ts1: OperationTimestamp, ts2: OperationTimestamp): boolean {
-  return ((ts1.transactionNumber < ts2.transactionNumber) ||
-          (ts1.transactionNumber === ts2.transactionNumber) && (ts1.operationIndex < ts2.operationIndex));
-}
-
-/**
- * Information about a write operation relevant for maintaining OperationProcessor state.
- */
-interface OperationInfo {
-  readonly type: OperationType;
-  readonly timestamp: OperationTimestamp;
-  readonly parent?: VersionId;
-
-  status: OperationStatus;
-
-  // Most recent missing ancestor if one of the ancestors is missing. Defined only if status
-  // is Unvalidated.
-  missingAncestor?: VersionId;
 }
 
 /**
@@ -165,148 +44,68 @@ interface OperationInfo {
  */
 class OperationProcessorImpl implements OperationProcessor {
 
-  /**
-   * Map a operation hash to the OperationInfo which contains sufficient
-   * information to reconstruct the operation.
-   */
-  private opHashToInfo: Map<OperationHash, OperationInfo> = new Map();
-
-  /**
-   * The set of deleted DIDs.
-   */
-  private deletedDids: Set<string> = new Set();
-
-  /**
-   * Map a valid versionId to the next valid versionId whenever one exists. The next
-   * version of a valid node is a valid child node. There is at most one valid child node
-   * (it could have zero) due to our validity checks (condition 3 in comment above Valid).
-   */
-  private nextVersion: Map<VersionId, VersionId> = new Map();
-
-  /**
-   * Map a "missing" operation (hash) to the list of descendant operations. The
-   * missing operation is the nearest ancestor of each of the descendants. The
-   * descendants are listed in topological sort order. For example, given these operations
-   *
-   *               m <- o1 <- o2 <- o3
-   *                      \
-   *                       \<- o4 <- o5.
-   *
-   * the linked list for missing operation m might be o1 - o4 - o5 - o2 - o3, but not
-   * o1 - o3 - o2 - o4 - o5.
-   *
-   */
-  private waitingDescendants: Map<OperationHash, LinkedList<OperationHash>> = new Map();
-
   private operationStore: OperationStore;
 
-  /**
-   * The list of deferred (unapplied) operations, stored as a mapping from each did to the list
-   * of deferred operations for the did.
-   */
-  private deferredOperations: Map<OperationHash, LinkedList<OperationHash>> = new Map();
-
-  public constructor (private readonly cas: Cas, private didMethodName: string) {
-    this.operationStore = new OperationStore(this.cas);
+  public constructor (private didMethodName: string) {
+    this.operationStore = createOperationStore(didMethodName);
   }
 
   /**
-   * Processes a specified DID state changing operation. The current implementation simply stores the operation
-   * in a deferred operations list and returns the hash of the operation. The deferred operations for a
-   * particular did are processed during the next resolve of the did.
+   * Processes a specified DID state changing operation. The current implementation inserts
+   * the operation in the store and returns the hash of the operation.
    */
-  public async process (operation: WriteOperation): Promise<string> {
-    const opHash = getOperationHash(operation);
-
-    // Throw errors if missing any required metadata:
-    // any operation anchored in a blockchain must have this metadata.
-    if (operation.transactionTime === undefined) {
-      throw Error('Invalid operation: transactionTime undefined');
-    }
-
-    if (operation.transactionNumber === undefined) {
-      throw Error('Invalid operation: transactionNumber undefined');
-    }
-
-    if (operation.operationIndex === undefined) {
-      throw Error('Invalid operation: operationIndex undefined');
-    }
-
-    if (operation.batchFileHash === undefined) {
-      throw Error('Invalid operation: batchFileHash undefined');
-    }
-
-    this.operationStore.store(opHash, operation);
-
-    const did = this.getDidUniqueSuffix(operation, opHash);
-    this.getDeferredOperationsList(did).append(opHash);
-
-    return opHash;
+  public async process (operation: WriteOperation): Promise<void> {
+    return this.operationStore.put(operation);
   }
 
   /**
    * Remove all previously processed operations
-   * with transactionNumber greater than the provided transaction number.
+   * with transactionNumber greater or equal to the provided transaction number.
    * If no transaction number is given, all operations are rolled back (unlikely scenario).
    * The intended use case for this method is to handle rollbacks
    * in the blockchain.
-   *
-   * The current implementation is inefficient: It simply scans the two
-   * hashmaps storing the core Did state and removes all entries with
-   * a greater transaction number.  In future, the implementation should be optimized
-   * for the common case by keeping a sliding window of recent operations.
    */
   public async rollback (transactionNumber?: number): Promise<void> {
+    return this.operationStore.delete(transactionNumber);
+  }
 
-    // If no transaction number is given to rollback to, rollback everything.
-    if (!transactionNumber) {
-      console.warn('Rolling back all operations...');
-      this.opHashToInfo.clear();
-      this.deletedDids.clear();
-      this.nextVersion.clear();
-      this.waitingDescendants.clear();
-      this.operationStore = new OperationStore(this.cas);
-      console.warn('Rolled back all operations.');
-      return;
+  private async isValid (operation: WriteOperation, previousOperation: WriteOperation | undefined, currentDidDocument: DidDocument | undefined):
+    Promise<boolean> {
+
+    if (operation.type === OperationType.Create) {
+      // TODO: Add signature verification for create operation
+      return true;
+    } else {
+      // Every operation other than a create has a previous operation and a valid
+      // current DID document.
+      if (!previousOperation || !currentDidDocument) {
+        return false;
+      }
+
+      // If previous operation is a delete, then any subsequent operation is not valid
+      if (previousOperation.type === OperationType.Delete) {
+        return false;
+      }
+
+      const publicKey = OperationProcessorImpl.getPublicKey(currentDidDocument, operation.signingKeyId);
+      if (!publicKey) {
+        return false;
+      }
+
+      if (!(await Cryptography.verifySignature(operation.encodedPayload, operation.signature, publicKey))) {
+        return false;
+      }
+
+      return true;
     }
+  }
 
-    // Iterate over all operations and remove those with with
-    // transactionNumber greater or equal to the provided parameter.
-    // applied operations are in opHashToInfo structure...
-    this.opHashToInfo.forEach((opInfo, opHash, map) => {
-      if (opInfo.timestamp.transactionNumber >= transactionNumber) {
-
-        // In addition to removing the obsolete operation from the opHashToInfo map (after this if-block),
-        // If the obsolete operation was considered valid, then the parent's next link is invalid, need to remove the next link also.
-        // Else if the operation has a missing ancestor, then need to remove the operation from the list of waiting descendants of the missing ancestor.
-        if (opInfo.status === OperationStatus.Valid) {
-          this.invalidatePreviouslyValidOperation(opHash);
-        } else if (opInfo.status === OperationStatus.Unvalidated) {
-          const missingAncestor = opInfo.missingAncestor!;
-          const waitingDescendantsOfAncestor = this.waitingDescendants.get(missingAncestor)!;
-          waitingDescendantsOfAncestor.remove(opHash);
-        }
-
-        map.delete(opHash);
-      }
-    });
-
-    // ... deferred operations are in the deferred operations list
-    for (const [, opList] of this.deferredOperations.entries()) {
-      // The documentation for LinkedList does not say anything about iteration with list updates.
-      // To be safe, we store the deleted operations in a separate list and delete them after the
-      // iteration of opList.
-      const deletedOpList = new LinkedList<OperationHash>();
-      for (const opHash of opList) {
-        const operator = await this.operationStore.lookup(opHash);
-        if (operator.transactionNumber! >= transactionNumber) {
-          deletedOpList.append(opHash);
-        }
-      }
-
-      for (const deletedOpHash of deletedOpList) {
-        opList.remove(deletedOpHash);
-      }
+  private getUpdatedDocument (didDocument: DidDocument | undefined, operation: WriteOperation): DidDocument {
+    if (operation.type === OperationType.Create) {
+      const protocolVersion = Protocol.getProtocol(operation.transactionTime!);
+      return Document.from(operation.encodedPayload, this.didMethodName, protocolVersion.hashAlgorithmInMultihashCode);
+    } else {
+      return WriteOperation.applyJsonPatchToDidDocument(didDocument!, operation.patch!);
     }
   }
 
@@ -316,337 +115,19 @@ class OperationProcessorImpl implements OperationProcessor {
    * @returns DID Document of the given DID. Undefined if the DID is deleted or not found.
    */
   public async resolve (did: string): Promise<DidDocument | undefined> {
+    let didDocument: DidDocument | undefined;
+    let previousOperation: WriteOperation | undefined;
+
     const didUniqueSuffix = did.substring(this.didMethodName.length);
 
-    await this.processDeferredOperationsOfDid(didUniqueSuffix);
-
-    if (this.deletedDids.has(did)) {
-      return undefined;
-    }
-
-    const latestVersion = await this.last(didUniqueSuffix);
-
-    // lastVersion === undefined implies we do not know about the did
-    if (latestVersion === undefined) {
-      return undefined;
-    }
-
-    return this.lookup(latestVersion);
-  }
-
-  /**
-   * Returns the DID Document for a given version identifier.
-   */
-  public async lookup (versionId: VersionId): Promise<DidDocument | undefined> {
-    // Version id is also the operation hash that produces the document
-    const opHash = versionId;
-
-    const opInfo = this.opHashToInfo.get(opHash);
-
-    // We don't know anything about this operation
-    if (opInfo === undefined) {
-      return undefined;
-    }
-
-    // Construct the operation using a CAS lookup
-    const op = await this.operationStore.lookup(opHash);
-
-    if (this.isInitialVersion(opInfo)) {
-      const protocolVersion = Protocol.getProtocol(op.transactionTime!);
-      return Document.from(op.encodedPayload, this.didMethodName, protocolVersion.hashAlgorithmInMultihashCode);
-    } else {
-      const prevVersion = op.previousOperationHash!;
-      const prevDidDoc = await this.lookup(prevVersion);
-      if (prevDidDoc === undefined) {
-        return undefined;
-      } else {
-        return WriteOperation.applyJsonPatchToDidDocument(prevDidDoc, op.patch!);
-      }
-    }
-  }
-
-  /**
-   * Return the previous version id of a given DID version. The implementation
-   * is inefficient and involves an async cas read. This should not be a problem
-   * since this method is not hit for any of the externally exposed DID operations.
-   */
-  public async previous (versionId: VersionId): Promise<VersionId | undefined> {
-    const opInfo = this.opHashToInfo.get(versionId);
-    if (opInfo !== undefined) {
-      return opInfo.parent;
-    }
-    return undefined;
-  }
-
-  /**
-   * Return the first version of a DID document given a possibly later version.
-   * A simple recursive implementation using prev; not very efficient but should
-   * not matter since this method is not hit for any externally exposed DID
-   * operations.
-   */
-  public async first (versionId: VersionId): Promise<VersionId | undefined> {
-    const opInfo = this.opHashToInfo.get(versionId);
-    if (opInfo === undefined) {
-      return undefined;
-    }
-
-    while (true) {
-      const prevVersionId = await this.previous(versionId);
-      if (prevVersionId === undefined) {
-        return versionId;
-      }
-
-      versionId = prevVersionId;
-    }
-  }
-
-  /**
-   * Return the next version of a DID document if it exists or undefined otherwise.
-   */
-  public async next (versionId: VersionId): Promise<VersionId | undefined> {
-    const nextVersionId = this.nextVersion.get(versionId);
-    if (nextVersionId === undefined) {
-      return undefined;
-    } else {
-      return nextVersionId;
-    }
-  }
-
-  /**
-   * Returns the latest (most recent) version of a DID Document.
-   * Returns undefined if the version is unknown.
-   */
-  public async last (versionId: VersionId): Promise<VersionId | undefined> {
-
-    const opInfo = this.opHashToInfo.get(versionId);
-    if (opInfo === undefined) {
-      return undefined;
-    }
-
-    while (true) {
-      const nextVersionId = await this.next(versionId);
-      if (nextVersionId === undefined) {
-        return versionId;
-      } else {
-        versionId = nextVersionId;
-      }
-    }
-  }
-
-  /**
-   * Return true if the provided operation is an initial version i.e.,
-   * produced by a create operation.
-   */
-  private isInitialVersion (opInfo: OperationInfo): boolean {
-    return opInfo.type === OperationType.Create;
-  }
-
-  /**
-   * Processes a specified DID state changing operation.
-   */
-  private async processOperation (opHash: OperationHash): Promise<void> {
-    const operation = await this.operationStore.lookup(opHash);
-
-    // opInfo is operation with derivable properties projected out
-    const opTimestamp: OperationTimestamp = {
-      transactionNumber: operation.transactionNumber!,
-      operationIndex: operation.operationIndex!
-    };
-
-    const opInfo: OperationInfo = {
-      type: operation.type,
-      timestamp: opTimestamp,
-      parent: operation.previousOperationHash,
-      status: OperationStatus.Unvalidated
-    };
-
-    // If there is already a known operation with the same hash
-    // and that operation is timestamped earlier than this incoming one being processed,
-    // we can ignore incoming operation because the earlier operation of the same hash takes precedence.
-    const existingOperationInfo = this.opHashToInfo.get(opHash);
-    if (existingOperationInfo !== undefined && earlier(existingOperationInfo.timestamp, opInfo.timestamp)) {
-      return undefined;
-    }
-
-    // Update our mapping of operation hash to operation info overwriting
-    // previous info if it exists
-    this.opHashToInfo.set(opHash, opInfo);
-
-    if (operation.type === OperationType.Delete ||
-        operation.type === OperationType.Recover) {
-      // NOTE: only assuming and hanldling delete currently.
-      // TODO: validate recovery key.
-
-      this.deletedDids.add(operation.did!);
-    }
-
-    // Else the operation is a create or an update.
-    await this.processInternal(opHash, opInfo);
-  }
-
-  private async processInternal (opHash: OperationHash, opInfo: OperationInfo): Promise<void> {
-    // Create operation (which has no parents) is handled differently from the other
-    // operations which do have parents.
-    if (opInfo.type === OperationType.Create) {
-      await this.processCreateOperation(opHash, opInfo);
-    } else {
-      await this.processOperationWithParent(opHash, opInfo);
-    }
-
-    // Process operations waiting on this operation
-    await this.processDescendantsWaitingOn(opHash);
-  }
-
-  private async processCreateOperation (operationHash: OperationHash, operationInfo: OperationInfo): Promise<void> {
-    // Get the DID Document formed up until the parent operation.
-    const didDocument = await this.lookup(operationHash);
-
-    // Fetch the public key to be used for signature verification.
-    const operation = await this.operationStore.lookup(operationHash);
-    const publicKey = OperationProcessorImpl.getPublicKey(didDocument!, operation.signingKeyId);
-
-    // Signature verification.
-    let verified = false;
-    if (publicKey) {
-      verified = await Cryptography.verifySignature(operation.encodedPayload, operation.signature, publicKey);
-    }
-
-    if (verified) {
-      operationInfo.status = OperationStatus.Valid;
-    } else {
-      operationInfo.status = OperationStatus.Invalid;
-    }
-  }
-
-  private async processOperationWithParent (opHash: OperationHash, opInfo: OperationInfo): Promise<void> {
-    const parentOpHash = opInfo.parent!;
-    const parentOpInfo = this.opHashToInfo.get(parentOpHash);
-
-    // If we do not know about the parent, then the ancestry of this operation is incomplete.
-    // The operation status is Unvalidated so we add this operation to the list of waiting descendants
-    // of the parent operation (hash).
-    if (parentOpInfo === undefined) {
-      opInfo.status = OperationStatus.Unvalidated;
-      opInfo.missingAncestor = parentOpHash;
-      this.addWaitingDescendants(opInfo.missingAncestor, opHash);
-      return;
-    }
-
-    // The parent has an Unvalidated status. This implies an incomplete ancestry of the
-    // parent and therefore of this operation. We leave the status to be Unvalidated and
-    // update the waitingDescendants of the closest missing ancestor.
-    if (parentOpInfo.status === OperationStatus.Unvalidated) {
-      opInfo.missingAncestor = parentOpInfo.missingAncestor!;
-      this.addWaitingDescendants(opInfo.missingAncestor, opHash);
-      return;
-    }
-
-    // If the parent is invalid, then this operation is invalid as well.
-    if (parentOpInfo.status === OperationStatus.Invalid) {
-      opInfo.status = OperationStatus.Invalid;
-      return;
-    }
-
-    // Assert: parentOpInfo.status === OperationStatus.Valid. Validate the operation
-    if (!await this.validate(opHash, opInfo)) {
-      opInfo.status = OperationStatus.Invalid;
-      return;
-    }
-
-    // The operation is intrinsically valid. Before we set it to valid, we need
-    // to ensure that it is the earliest sibling among child nodes of its parent.
-    const earliestSiblingHash = this.nextVersion.get(parentOpHash);
-
-    if (earliestSiblingHash !== undefined) {
-      const earliestSiblingInfo = this.opHashToInfo.get(earliestSiblingHash)!;
-
-      // If the existing earliest sibling operation is earlier than the operation to be added,
-      //   then the operation to be added is invalid.
-      // Else current operation is the earliest sibling operation and thus is valid,
-      //   the existing sibling's entire descendant chain in the next version map need to be removed.
-      if (earlier(earliestSiblingInfo.timestamp, opInfo.timestamp)) {
-        opInfo.status = OperationStatus.Invalid;
-        return;
-      } else {
-        let opToInvalidate: string | undefined = earliestSiblingHash;
-        do {
-          this.invalidatePreviouslyValidOperation(opToInvalidate);
-          opToInvalidate = this.nextVersion.get(opToInvalidate);
-        } while (opToInvalidate !== undefined);
-        // fall through ...
+    const didOps = await this.operationStore.get(didUniqueSuffix);
+    for (const operation of didOps) {
+      if (await this.isValid(operation, previousOperation, didDocument)) {
+        didDocument = this.getUpdatedDocument(didDocument, operation);
       }
     }
 
-    opInfo.status = OperationStatus.Valid;
-    this.nextVersion.set(parentOpHash, opHash);
-    return;
-  }
-
-  private addWaitingDescendants (missingAncestor: OperationHash, opHash: OperationHash) {
-    const waitingDescendants = this.waitingDescendants.get(missingAncestor);
-    if (waitingDescendants === undefined) {
-      this.waitingDescendants.set(missingAncestor, new LinkedList<OperationHash>(opHash));
-    } else {
-      waitingDescendants.append(opHash);
-    }
-  }
-
-  private async validate (opHash: OperationHash, opInfo: OperationInfo): Promise<boolean> {
-    const parentOpHash = opInfo.parent!;
-    const parentOpInfo = this.opHashToInfo.get(parentOpHash)!;
-    // Assert: parentOpInfo.status === OperationStatus.Valid.
-
-    if (!earlier(parentOpInfo.timestamp, opInfo.timestamp)) {
-      return false;
-    }
-
-    // TODO Perform:
-    // - operation number validation
-
-    // Get the DID Document formed up until the parent operation.
-    const didDocument = await this.lookup(parentOpHash);
-
-    // Fetch the public key to be used for signature verification.
-    const operation = await this.operationStore.lookup(opHash);
-    const publicKey = OperationProcessorImpl.getPublicKey(didDocument!, operation.signingKeyId);
-
-    // Signature verification.
-    let verified = false;
-    if (publicKey) {
-      verified = await Cryptography.verifySignature(operation.encodedPayload, operation.signature, publicKey);
-    }
-    return verified;
-
-    return true;
-  }
-
-  /**
-   * Invalidates the given operation by:
-   * 1. Removing its parent's reference to it in the next version map.
-   * 2. Sets the operation status to be 'Invalid'.
-   * @param opHash The hash of the operation to be invalidated.
-   */
-  private invalidatePreviouslyValidOperation (opHash: OperationHash) {
-    const opInfo = this.opHashToInfo.get(opHash)!;
-
-    if (opInfo.parent) {
-      this.nextVersion.delete(opInfo.parent);
-    }
-
-    opInfo.status = OperationStatus.Invalid;
-  }
-
-  private async processDescendantsWaitingOn (opHash: OperationHash) {
-    const waitingDescendants = this.waitingDescendants.get(opHash);
-    if (waitingDescendants === undefined) {
-      return;
-    }
-
-    for (const descendantHash of waitingDescendants) {
-      const descendantInfo = this.opHashToInfo.get(descendantHash)!;
-      // assert: descendantInfo.status === Unvalidated and descendantInfo.missingAncestor === opHash
-      await this.processInternal(descendantHash, descendantInfo);
-    }
+    return didDocument;
   }
 
   /**
@@ -665,51 +146,11 @@ class OperationProcessorImpl implements OperationProcessor {
 
     return undefined;
   }
-
-  /**
-   * Get the deferred operations list for a did. If the list is not present,
-   * an empty list is created and associated with the did, and returned as output.
-   */
-  private getDeferredOperationsList (did: string): LinkedList<OperationHash> {
-    let deferredOperationsList = this.deferredOperations.get(did);
-    if (deferredOperationsList === undefined) {
-      deferredOperationsList = new LinkedList();
-      this.deferredOperations.set(did, deferredOperationsList);
-    }
-
-    return deferredOperationsList;
-  }
-
-  /**
-   * Gets the DID unique suffix of an operation. For create operation, this is the operation hash;
-   * for others the DID included with the operation can be used to obtain the unique suffix.
-   */
-  private getDidUniqueSuffix (operation: WriteOperation, operationHash: OperationHash): string {
-    if (operation.type === OperationType.Create) {
-      return operationHash;
-    } else {
-      const didUniqueSuffix = operation.did!.substring(this.didMethodName.length);
-      return didUniqueSuffix;
-    }
-  }
-
-  /**
-   * Iterate over the deferred (unapplied) operations of a did and process the same.
-   */
-  private async processDeferredOperationsOfDid (did: string): Promise<void> {
-    const deferredOperationsList = this.deferredOperations.get(did);
-    if (deferredOperationsList !== undefined) {
-      for (const deferredOpHash of deferredOperationsList) {
-        await this.processOperation(deferredOpHash);
-      }
-      this.deferredOperations.delete(did);
-    }
-  }
 }
 
 /**
  * Factory function for creating a operation processor
  */
-export function createOperationProcessor (cas: Cas, didMethodName: string): OperationProcessor {
-  return new OperationProcessorImpl(cas, didMethodName);
+export function createOperationProcessor (_cas: Cas, didMethodName: string): OperationProcessor {
+  return new OperationProcessorImpl(didMethodName);
 }

--- a/src/OperationProcessor.ts
+++ b/src/OperationProcessor.ts
@@ -124,6 +124,7 @@ class OperationProcessorImpl implements OperationProcessor {
     for (const operation of didOps) {
       if (await this.isValid(operation, previousOperation, didDocument)) {
         didDocument = this.getUpdatedDocument(didDocument, operation);
+        previousOperation = operation;
       }
     }
 

--- a/src/OperationProcessor.ts
+++ b/src/OperationProcessor.ts
@@ -1,5 +1,5 @@
 import * as Protocol from './Protocol';
-import { Cas } from '../src/Cas';
+import { Cas } from './Cas';
 import Cryptography from './lib/Cryptography';
 import DidPublicKey from './lib/DidPublicKey';
 import Document from './lib/Document';

--- a/src/OperationProcessor.ts
+++ b/src/OperationProcessor.ts
@@ -86,6 +86,10 @@ class OperationProcessorImpl implements OperationProcessor {
       if (await this.isValid(operation, previousOperation, didDocument)) {
         didDocument = this.getUpdatedDocument(didDocument, operation);
         previousOperation = operation;
+
+        if (operation.type === OperationType.Delete) {
+          break;
+        }
       }
     }
 
@@ -129,11 +133,6 @@ class OperationProcessorImpl implements OperationProcessor {
         return false;
       }
 
-      // If previous operation is a delete, then any subsequent operation is not valid
-      if (previousOperation.type === OperationType.Delete) {
-        return false;
-      }
-
       // Any non-create needs a previous operation hash  ...
       if (!operation.previousOperationHash) {
         return false;
@@ -169,7 +168,7 @@ class OperationProcessorImpl implements OperationProcessor {
   }
 
   // Get the initial DID document for a create operation
-  private getInitialDocument(createOperation: Operation): DidDocument {
+  private getInitialDocument (createOperation: Operation): DidDocument {
     const protocolVersion = Protocol.getProtocol(createOperation.transactionTime!);
     return Document.from(createOperation.encodedPayload, this.didMethodName, protocolVersion.hashAlgorithmInMultihashCode);
   }

--- a/src/OperationStore.ts
+++ b/src/OperationStore.ts
@@ -62,7 +62,7 @@ class OperationStoreImpl {
 
     this.ensureDidEntriesExist(did);
     this.didToOperations.get(did)!.push(operation);
-    this.didTouchedSinceLastSort.set(did, false);
+    this.didTouchedSinceLastSort.set(did, true);
   }
 
   /**

--- a/src/OperationStore.ts
+++ b/src/OperationStore.ts
@@ -19,7 +19,7 @@ export interface OperationStore {
   get (didUniqueSuffix: string): Promise<Iterable<Operation>>;
 
   /**
-   * Delete all operations with transaction number greater than the 
+   * Delete all operations with transaction number greater than the
    * provided parameter.
    */
   delete (transactionNumber?: number): Promise<void>;

--- a/tests/OperationProcessor.spec.ts
+++ b/tests/OperationProcessor.spec.ts
@@ -134,7 +134,6 @@ describe('OperationProessor', async () => {
   let cas = new MockCas();
   let operationProcessor = createOperationProcessor(cas, didMethodName);
   let createOp: WriteOperation | undefined;
-  let firstVersion: string | undefined;
   let publicKey: any;
   let privateKey: any;
   let did: string;
@@ -153,7 +152,6 @@ describe('OperationProessor', async () => {
   });
 
   it('should return a DID Document for resolve(did) for a registered DID', async () => {
-    const did = `${didMethodName}${firstVersion!}`;
     const didDocument = await operationProcessor.resolve(did);
 
     // TODO: can we get the raw json from did? if so, we can write a better test.
@@ -161,8 +159,9 @@ describe('OperationProessor', async () => {
     expect(didDocument).toBeDefined();
     const publicKey2 = getPublicKey(didDocument!, 'key2');
     expect(publicKey2).toBeDefined();
-    expect(publicKey2!.publicKeyHex!).toEqual('-----BEGIN PUBLIC KEY.2.END PUBLIC KEY-----');
-  });
+    expect(publicKey2!.owner).toBeDefined();
+    expect(publicKey2!.owner!).toEqual('did:sidetree:ignoredUnlessResolvable');
+  }); 
 
   it('should process updates correctly', async () => {
     const numberOfUpdates = 10;
@@ -179,12 +178,12 @@ describe('OperationProessor', async () => {
     expect(publicKey2!.owner).toBeDefined();
     expect(publicKey2!.owner!).toEqual('did:sidetree:updateid' + (numberOfUpdates - 1));
   });
-
+  
   it('should correctly process updates in reverse order', async () => {
     const numberOfUpdates = 10;
     const ops = await createUpdateSequence(did, createOp!, cas, numberOfUpdates, privateKey);
 
-    for (let i = numberOfUpdates ; i > 0 ; --i) {
+    for (let i = numberOfUpdates ; i >= 0 ; --i) {
       await operationProcessor.process(ops[i]);
     }
     const didDocument = await operationProcessor.resolve(did);

--- a/tests/OperationProcessor.spec.ts
+++ b/tests/OperationProcessor.spec.ts
@@ -225,7 +225,7 @@ describe('OperationProessor', async () => {
     // Create and upload the batch file with the invalid operation.
     const operationBuffer = Buffer.from(JSON.stringify(operation));
     const createOperation = await addBatchFileOfOneOperationToCas(operationBuffer, cas, 1, 0, 0);
-    
+
     // Trigger processing of the operation.
     await operationProcessor.process(createOperation);
     const did = didMethodName + getOperationHash(createOperation);

--- a/tests/OperationProcessor.spec.ts
+++ b/tests/OperationProcessor.spec.ts
@@ -161,7 +161,7 @@ describe('OperationProessor', async () => {
     expect(publicKey2).toBeDefined();
     expect(publicKey2!.owner).toBeDefined();
     expect(publicKey2!.owner!).toEqual('did:sidetree:ignoredUnlessResolvable');
-  }); 
+  });
 
   it('should process updates correctly', async () => {
     const numberOfUpdates = 10;
@@ -178,7 +178,7 @@ describe('OperationProessor', async () => {
     expect(publicKey2!.owner).toBeDefined();
     expect(publicKey2!.owner!).toEqual('did:sidetree:updateid' + (numberOfUpdates - 1));
   });
-  
+
   it('should correctly process updates in reverse order', async () => {
     const numberOfUpdates = 10;
     const ops = await createUpdateSequence(did, createOp!, cas, numberOfUpdates, privateKey);


### PR DESCRIPTION
This PR (a) significantly simplifies the OperationProcessor code by avoiding any computation caching (all work is done at resolve time); (b) changes the OperationStore interface to prepare for persistence.